### PR TITLE
Use qtPrepareTool to find proper lrelease

### DIFF
--- a/crow-translate.pro
+++ b/crow-translate.pro
@@ -70,7 +70,8 @@ TRANSLATIONS += \
     data/translations/crow_ru.ts
 
 # Compile translations
-system(lrelease crow-translate.pro)
+qtPrepareTool(LRELEASE, lrelease)
+system($$LRELEASE crow-translate.pro) | error("Failed to run lrelease")
 
 # For make install
 unix {


### PR DESCRIPTION
Many Linux distributions install it as lrelease-qt5.