### PR TITLE
Autofocus source text when main window is shown

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -177,6 +177,7 @@ void MainWindow::activate()
 {
     show();
     activateWindow();
+    ui->sourceEdit->setFocus();
     raise();
 }
 


### PR DESCRIPTION
This allows user to start enter text immediately after opening crow window. Currently previous focused element is remembered.