### PR TITLE
Fix focus on input field when main window activates

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -177,8 +177,8 @@ void MainWindow::activate()
 {
     show();
     activateWindow();
-    ui->sourceEdit->setFocus();
     raise();
+    ui->sourceEdit->setFocus();
 }
 
 QComboBox *MainWindow::engineCombobox()


### PR DESCRIPTION
raise() will set focus on it own on the first element, so focus on any widget before raise() will not work. This PR swap ui->sourceEdit->setFocus() and raise() to fix this.