### PR TITLE
Enable swapping languages from D-Bus

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,21 +110,23 @@ The program also has a console interface.
 
     io.crow_translate.CrowTranslate
     └── /io/crow_translate/CrowTranslate/MainWindow
-        ├── method void io.crow_translate.CrowTranslate.MainWindow.abortTranslation()
-        ├── method void io.crow_translate.CrowTranslate.MainWindow.clearText()
-        ├── method void io.crow_translate.CrowTranslate.MainWindow.copyAllTranslationInfo()
-        ├── method void io.crow_translate.CrowTranslate.MainWindow.copySourceText()
-        ├── method void io.crow_translate.CrowTranslate.MainWindow.copyTranslatedSelection()
-        ├── method void io.crow_translate.CrowTranslate.MainWindow.copyTranslation()
-        ├── method void io.crow_translate.CrowTranslate.MainWindow.open()
-        ├── method void io.crow_translate.CrowTranslate.MainWindow.openSettings()
-        ├── method void io.crow_translate.CrowTranslate.MainWindow.quit()
-        ├── method void io.crow_translate.CrowTranslate.MainWindow.setAutoTranslateEnabled(bool enabled)
-        ├── method void io.crow_translate.CrowTranslate.MainWindow.speakSelection()
-        ├── method void io.crow_translate.CrowTranslate.MainWindow.speakTranslatedSelection()
-        ├── method void io.crow_translate.CrowTranslate.MainWindow.stopSpeaking()
-        ├── method void io.crow_translate.CrowTranslate.MainWindow.swapLanguages()
-        └── method void io.crow_translate.CrowTranslate.MainWindow.translateSelection()
+        |   # Global shortcuts
+        ├── method void io.crow_translate.CrowTranslate.MainWindow.translateSelection();
+        ├── method void io.crow_translate.CrowTranslate.MainWindow.speakSelection();
+        ├── method void io.crow_translate.CrowTranslate.MainWindow.speakTranslatedSelection();
+        ├── method void io.crow_translate.CrowTranslate.MainWindow.stopSpeaking();
+        ├── method void io.crow_translate.CrowTranslate.MainWindow.open();
+        ├── method void io.crow_translate.CrowTranslate.MainWindow.copyTranslatedSelection();
+        |   # Main window shortcuts
+        ├── method void io.crow_translate.CrowTranslate.MainWindow.clearText();
+        ├── method void io.crow_translate.CrowTranslate.MainWindow.abortTranslation();
+        ├── method void io.crow_translate.CrowTranslate.MainWindow.swapLanguages();
+        ├── method void io.crow_translate.CrowTranslate.MainWindow.openSettings();
+        ├── method void io.crow_translate.CrowTranslate.MainWindow.setAutoTranslateEnabled(bool enabled);
+        ├── method void io.crow_translate.CrowTranslate.MainWindow.copySourceText();
+        ├── method void io.crow_translate.CrowTranslate.MainWindow.copyTranslation();
+        ├── method void io.crow_translate.CrowTranslate.MainWindow.copyAllTranslationInfo();
+        └── method void io.crow_translate.CrowTranslate.MainWindow.quit();
 
 For example, you can show main window using `dbus-send`:
 

--- a/README.md
+++ b/README.md
@@ -108,17 +108,23 @@ The program also has a console interface.
 
 ## D-Bus API
 
-Currently available only for [global shortcuts](#global).
-
     io.crow_translate.CrowTranslate
     └── /io/crow_translate/CrowTranslate/MainWindow
+        ├── method void io.crow_translate.CrowTranslate.MainWindow.abortTranslation()
+        ├── method void io.crow_translate.CrowTranslate.MainWindow.clearText()
+        ├── method void io.crow_translate.CrowTranslate.MainWindow.copyAllTranslationInfo()
+        ├── method void io.crow_translate.CrowTranslate.MainWindow.copySourceText()
         ├── method void io.crow_translate.CrowTranslate.MainWindow.copyTranslatedSelection()
+        ├── method void io.crow_translate.CrowTranslate.MainWindow.copyTranslation()
         ├── method void io.crow_translate.CrowTranslate.MainWindow.open()
+        ├── method void io.crow_translate.CrowTranslate.MainWindow.openSettings()
+        ├── method void io.crow_translate.CrowTranslate.MainWindow.quit()
+        ├── method void io.crow_translate.CrowTranslate.MainWindow.setAutoTranslateEnabled(bool enabled)
         ├── method void io.crow_translate.CrowTranslate.MainWindow.speakSelection()
         ├── method void io.crow_translate.CrowTranslate.MainWindow.speakTranslatedSelection()
         ├── method void io.crow_translate.CrowTranslate.MainWindow.stopSpeaking()
-        ├── method void io.crow_translate.CrowTranslate.MainWindow.translateSelection()
-        └── method void io.crow_translate.CrowTranslate.MainWindow.quit()
+        ├── method void io.crow_translate.CrowTranslate.MainWindow.swapLanguages()
+        └── method void io.crow_translate.CrowTranslate.MainWindow.translateSelection()
 
 For example, you can show main window using `dbus-send`:
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -457,6 +457,7 @@ void MainWindow::openSettings()
 void MainWindow::setAutoTranslateEnabled(bool enabled)
 {
     ui->sourceEdit->setRequestTranlationOnEdit(enabled);
+    ui->autoTranslateCheckBox->setChecked(enabled);
     if (enabled)
         ui->sourceEdit->markSourceAsChanged();
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -267,6 +267,71 @@ void MainWindow::copyTranslatedSelection()
     emit copyTranslatedSelectionRequested();
 }
 
+void MainWindow::clearText()
+{
+    // Clear source text without tracking for changes
+    ui->sourceEdit->setRequestTranlationOnEdit(false);
+    ui->sourceEdit->clear();
+    if (ui->autoTranslateCheckBox->isChecked())
+        ui->sourceEdit->setRequestTranlationOnEdit(true);
+
+    clearTranslation();
+}
+
+void MainWindow::abortTranslation()
+{
+    m_translator->abort();
+}
+
+void MainWindow::swapLanguages()
+{
+    // Temporary disable toggle logic
+    disconnect(ui->translationLanguagesWidget, &LanguageButtonsWidget::buttonChecked, this, &MainWindow::checkLanguageButton);
+    disconnect(ui->sourceLanguagesWidget, &LanguageButtonsWidget::buttonChecked, this, &MainWindow::checkLanguageButton);
+
+    LanguageButtonsWidget::swapCurrentLanguages(ui->sourceLanguagesWidget, ui->translationLanguagesWidget);
+
+    // Re-enable toggle logic
+    connect(ui->translationLanguagesWidget, &LanguageButtonsWidget::buttonChecked, this, &MainWindow::checkLanguageButton);
+    connect(ui->sourceLanguagesWidget, &LanguageButtonsWidget::buttonChecked, this, &MainWindow::checkLanguageButton);
+
+    // Copy translation to source text
+    ui->sourceEdit->setPlainText(ui->translationEdit->translation());
+    ui->sourceEdit->moveCursor(QTextCursor::End);
+}
+
+void MainWindow::openSettings()
+{
+    SettingsDialog config(this);
+    if (config.exec() == QDialog::Accepted) {
+        const AppSettings settings;
+        loadSettings(settings);
+    }
+}
+
+void MainWindow::setAutoTranslateEnabled(bool enabled)
+{
+    ui->autoTranslateCheckBox->setChecked(enabled);
+}
+
+void MainWindow::copySourceText()
+{
+    if (!ui->sourceEdit->toPlainText().isEmpty())
+        QGuiApplication::clipboard()->setText(ui->sourceEdit->toPlainText());
+}
+
+void MainWindow::copyTranslation()
+{
+    if (!ui->translationEdit->toPlainText().isEmpty())
+        QGuiApplication::clipboard()->setText(ui->translationEdit->translation());
+}
+
+void MainWindow::copyAllTranslationInfo()
+{
+    if (!ui->translationEdit->toPlainText().isEmpty())
+        QGuiApplication::clipboard()->setText(ui->translationEdit->toPlainText());
+}
+
 void MainWindow::quit()
 {
 #if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
@@ -412,72 +477,11 @@ void MainWindow::forceAutodetect()
         ui->sourceEdit->setRequestTranlationOnEdit(true);
 }
 
-void MainWindow::clearText()
-{
-    // Clear source text without tracking for changes
-    ui->sourceEdit->setRequestTranlationOnEdit(false);
-    ui->sourceEdit->clear();
-    if (ui->autoTranslateCheckBox->isChecked())
-        ui->sourceEdit->setRequestTranlationOnEdit(true);
-
-    clearTranslation();
-}
-
-void MainWindow::abortTranslation()
-{
-    m_translator->abort();
-}
-
-void MainWindow::swapLanguages()
-{
-    // Temporary disable toggle logic
-    disconnect(ui->translationLanguagesWidget, &LanguageButtonsWidget::buttonChecked, this, &MainWindow::checkLanguageButton);
-    disconnect(ui->sourceLanguagesWidget, &LanguageButtonsWidget::buttonChecked, this, &MainWindow::checkLanguageButton);
-
-    LanguageButtonsWidget::swapCurrentLanguages(ui->sourceLanguagesWidget, ui->translationLanguagesWidget);
-
-    // Re-enable toggle logic
-    connect(ui->translationLanguagesWidget, &LanguageButtonsWidget::buttonChecked, this, &MainWindow::checkLanguageButton);
-    connect(ui->sourceLanguagesWidget, &LanguageButtonsWidget::buttonChecked, this, &MainWindow::checkLanguageButton);
-
-    // Copy translation to source text
-    ui->sourceEdit->setPlainText(ui->translationEdit->translation());
-    ui->sourceEdit->moveCursor(QTextCursor::End);
-}
-
-void MainWindow::openSettings()
-{
-    SettingsDialog config(this);
-    if (config.exec() == QDialog::Accepted) {
-        const AppSettings settings;
-        loadSettings(settings);
-    }
-}
-
-void MainWindow::setAutoTranslateEnabled(bool enabled)
+void MainWindow::setTranslationOnEditEnabled(bool enabled) 
 {
     ui->sourceEdit->setRequestTranlationOnEdit(enabled);
-    ui->autoTranslateCheckBox->setChecked(enabled);
     if (enabled)
         ui->sourceEdit->markSourceAsChanged();
-}
-
-void MainWindow::copySourceText()
-{
-    if (!ui->sourceEdit->toPlainText().isEmpty())
-        QGuiApplication::clipboard()->setText(ui->sourceEdit->toPlainText());
-}
-
-void MainWindow::copyTranslation()
-{
-    if (!ui->translationEdit->toPlainText().isEmpty())
-        QGuiApplication::clipboard()->setText(ui->translationEdit->translation());
-}
-
-void MainWindow::copyAllTranslationInfo()
-{
-    if (!ui->translationEdit->toPlainText().isEmpty())
-        QGuiApplication::clipboard()->setText(ui->translationEdit->toPlainText());
 }
 
 void MainWindow::resetAutoSourceButtonText()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -73,6 +73,14 @@ public slots:
     Q_SCRIPTABLE void open();
     Q_SCRIPTABLE void copyTranslatedSelection();
     Q_SCRIPTABLE void quit();
+    Q_SCRIPTABLE void clearText();
+    Q_SCRIPTABLE void abortTranslation();
+    Q_SCRIPTABLE void swapLanguages();
+    Q_SCRIPTABLE void openSettings();
+    Q_SCRIPTABLE void setAutoTranslateEnabled(bool enabled);
+    Q_SCRIPTABLE void copySourceText();
+    Q_SCRIPTABLE void copyTranslation();
+    Q_SCRIPTABLE void copyAllTranslationInfo();
 
 signals:
     void translateSelectionRequested();
@@ -100,16 +108,6 @@ private slots:
     void forceAutodetect();
 
     // UI
-    void clearText();
-    void abortTranslation();
-    void swapLanguages();
-    void openSettings();
-    void setAutoTranslateEnabled(bool enabled);
-
-    void copySourceText();
-    void copyTranslation();
-    void copyAllTranslationInfo();
-
     void resetAutoSourceButtonText();
     void setTaskbarState(QMediaPlayer::State state);
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -66,13 +66,15 @@ public:
     double popupOpacity() const;
 
 public slots:
+    // Global shortcuts
     Q_SCRIPTABLE void translateSelection();
     Q_SCRIPTABLE void speakSelection();
     Q_SCRIPTABLE void speakTranslatedSelection();
     Q_SCRIPTABLE void stopSpeaking();
     Q_SCRIPTABLE void open();
     Q_SCRIPTABLE void copyTranslatedSelection();
-    Q_SCRIPTABLE void quit();
+
+    // Main window shortcuts
     Q_SCRIPTABLE void clearText();
     Q_SCRIPTABLE void abortTranslation();
     Q_SCRIPTABLE void swapLanguages();
@@ -81,6 +83,7 @@ public slots:
     Q_SCRIPTABLE void copySourceText();
     Q_SCRIPTABLE void copyTranslation();
     Q_SCRIPTABLE void copyAllTranslationInfo();
+    Q_SCRIPTABLE void quit();
 
 signals:
     void translateSelectionRequested();
@@ -108,6 +111,7 @@ private slots:
     void forceAutodetect();
 
     // UI
+    void setTranslationOnEditEnabled(bool enabled);
     void resetAutoSourceButtonText();
     void setTaskbarState(QMediaPlayer::State state);
 

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -341,7 +341,7 @@
    <sender>autoTranslateCheckBox</sender>
    <signal>toggled(bool)</signal>
    <receiver>MainWindow</receiver>
-   <slot>setAutoTranslateEnabled(bool)</slot>
+   <slot>setTranslationOnEditEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>205</x>
@@ -486,7 +486,7 @@
   <slot>swapLanguages()</slot>
   <slot>openSettings()</slot>
   <slot>markSourceAsUpdated()</slot>
-  <slot>setAutoTranslateEnabled(bool)</slot>
+  <slot>setTranslationOnEditEnabled(bool)</slot>
   <slot>copySourceText()</slot>
   <slot>copyTranslation()</slot>
   <slot>copyAllTranslationInfo()</slot>


### PR DESCRIPTION
Closes #168.

I'm not familiar with Qt or C++ in general, but I've tested this and it appears to work fine. Question about the desktop file. Is the goal to provide actions for the most frequently used commands or for all of them? If it's the latter I can add a commit including a command for `swapLanguages` as well as `quit` which is currently missing in the desktop file.