### PR TITLE
Settings: Added 'translation notification display time' setting

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -383,7 +383,7 @@ void MainWindow::displayTranslation()
     // If window mode is notification, send a notification including the translation result
     const AppSettings settings;
     if (this->isHidden() && settings.windowMode() == AppSettings::Notification)
-        m_trayIcon->showMessage(tr("Translation Result"), ui->translationEdit->toPlainText(), QSystemTrayIcon::NoIcon, 3000);
+        m_trayIcon->showMessage(tr("Translation Result"), ui->translationEdit->toPlainText(), QSystemTrayIcon::NoIcon, m_translationNotificationDisplayTime*1000);
 }
 
 void MainWindow::clearTranslation()
@@ -795,6 +795,8 @@ void MainWindow::loadSettings(const AppSettings &settings)
 
     m_popupSize = {settings.popupWidth(), settings.popupHeight()};
     m_popupOpacity = settings.popupOpacity();
+
+    m_translationNotificationDisplayTime = settings.translationNotificationDisplayTime();
 
     ui->sourceLanguagesWidget->setLanguageFormat(settings.mainWindowLanguageFormat());
     ui->translationLanguagesWidget->setLanguageFormat(settings.mainWindowLanguageFormat());

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -383,7 +383,7 @@ void MainWindow::displayTranslation()
     // If window mode is notification, send a notification including the translation result
     const AppSettings settings;
     if (this->isHidden() && settings.windowMode() == AppSettings::Notification)
-        m_trayIcon->showMessage(tr("Translation Result"), ui->translationEdit->toPlainText(), QSystemTrayIcon::NoIcon, m_translationNotificationDisplayTime*1000);
+        m_trayIcon->showTranslationMessage(ui->translationEdit->toPlainText());
 }
 
 void MainWindow::clearTranslation()
@@ -795,8 +795,6 @@ void MainWindow::loadSettings(const AppSettings &settings)
 
     m_popupSize = {settings.popupWidth(), settings.popupHeight()};
     m_popupOpacity = settings.popupOpacity();
-
-    m_translationNotificationDisplayTime = settings.translationNotificationDisplayTime();
 
     ui->sourceLanguagesWidget->setLanguageFormat(settings.mainWindowLanguageFormat());
     ui->translationLanguagesWidget->setLanguageFormat(settings.mainWindowLanguageFormat());

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -161,8 +161,6 @@ private:
     AppSettings::LanguageFormat m_popupLanguageFormat;
     QSize m_popupSize;
     double m_popupOpacity;
-
-    int m_translationNotificationDisplayTime;
 };
 
 #endif // MAINWINDOW_H

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -161,6 +161,8 @@ private:
     AppSettings::LanguageFormat m_popupLanguageFormat;
     QSize m_popupSize;
     double m_popupOpacity;
+
+    int m_translationNotificationDisplayTime;
 };
 
 #endif // MAINWINDOW_H

--- a/src/settings/appsettings.cpp
+++ b/src/settings/appsettings.cpp
@@ -292,17 +292,17 @@ int AppSettings::defaultPopupWidth()
     return 350;
 }
 
-int AppSettings::translationNotificationDisplayTime() const
+int AppSettings::translationNotificationTimeout() const
 {
-    return m_settings->value(QStringLiteral("Interface/TranslationNotificationDisplayTime"), defaultTranslationNotificationDisplayTime()).toInt();
+    return m_settings->value(QStringLiteral("Interface/TranslationNotificationTimeout"), defaultTranslationNotificationTimeout()).toInt();
 }
 
-void AppSettings::setTranslationNotificationDisplayTime(int displayTime)
+void AppSettings::setTranslationNotificationTimeout(int timeout)
 {
-    m_settings->setValue(QStringLiteral("Interface/TranslationNotificationDisplayTime"), displayTime);
+    m_settings->setValue(QStringLiteral("Interface/TranslationNotificationTimeout"), timeout);
 }
 
-int AppSettings::defaultTranslationNotificationDisplayTime()
+int AppSettings::defaultTranslationNotificationTimeout()
 {
     return 3;
 }

--- a/src/settings/appsettings.cpp
+++ b/src/settings/appsettings.cpp
@@ -292,6 +292,21 @@ int AppSettings::defaultPopupWidth()
     return 350;
 }
 
+int AppSettings::translationNotificationDisplayTime() const
+{
+    return m_settings->value(QStringLiteral("Interface/TranslationNotificationDisplayTime"), defaultTranslationNotificationDisplayTime()).toInt();
+}
+
+void AppSettings::setTranslationNotificationDisplayTime(int displayTime)
+{
+    m_settings->setValue(QStringLiteral("Interface/TranslationNotificationDisplayTime"), displayTime);
+}
+
+int AppSettings::defaultTranslationNotificationDisplayTime()
+{
+    return 3;
+}
+
 AppSettings::LanguageFormat AppSettings::popupLanguageFormat() const
 {
     return m_settings->value(QStringLiteral("Interface/PopupLanguageFormat"), defaultPopupLanguageFormat()).value<LanguageFormat>();

--- a/src/settings/appsettings.h
+++ b/src/settings/appsettings.h
@@ -121,9 +121,9 @@ public:
     void setPopupWidth(int width);
     static int defaultPopupWidth();
 
-    int translationNotificationDisplayTime() const;
-    void setTranslationNotificationDisplayTime(int displayTime);
-    static int defaultTranslationNotificationDisplayTime();
+    int translationNotificationTimeout() const;
+    void setTranslationNotificationTimeout(int timeout);
+    static int defaultTranslationNotificationTimeout();
 
     LanguageFormat popupLanguageFormat() const;
     void setPopupLanguageFormat(LanguageFormat style);

--- a/src/settings/appsettings.h
+++ b/src/settings/appsettings.h
@@ -121,6 +121,10 @@ public:
     void setPopupWidth(int width);
     static int defaultPopupWidth();
 
+    int translationNotificationDisplayTime() const;
+    void setTranslationNotificationDisplayTime(int displayTime);
+    static int defaultTranslationNotificationDisplayTime();
+
     LanguageFormat popupLanguageFormat() const;
     void setPopupLanguageFormat(LanguageFormat style);
     static LanguageFormat defaultPopupLanguageFormat();

--- a/src/settings/settingsdialog.cpp
+++ b/src/settings/settingsdialog.cpp
@@ -98,6 +98,10 @@ SettingsDialog::SettingsDialog(QWidget *parent)
     ui->popupHeightSlider->setMinimum(200);
     ui->popupHeightSpinBox->setMinimum(200);
 
+    // Set maximum and minimum values for the time of the translation notification display
+    ui->translationNotificationDisplayTimeSpinBox->setMaximum(60);
+    ui->translationNotificationDisplayTimeSpinBox->setMinimum(1);
+
     // Disable (enable) opacity slider if "Window mode" ("Popup mode") selected
     connect(ui->windowModeComboBox, qOverload<int>(&QComboBox::currentIndexChanged), ui->popupOpacityLabel, &QSlider::setDisabled);
     connect(ui->windowModeComboBox, qOverload<int>(&QComboBox::currentIndexChanged), ui->popupOpacitySlider, &QSlider::setDisabled);
@@ -185,6 +189,8 @@ void SettingsDialog::accept()
     settings.setPopupOpacity(static_cast<double>(ui->popupOpacitySlider->value()) / 100);
     settings.setPopupWidth(ui->popupWidthSpinBox->value());
     settings.setPopupHeight(ui->popupHeightSpinBox->value());
+
+    settings.setTranslationNotificationDisplayTime(ui->translationNotificationDisplayTimeSpinBox->value());
 
     settings.setMainWindowLanguageFormat(static_cast<AppSettings::LanguageFormat>(ui->mainWindowLanguageFormatComboBox->currentIndex()));
     settings.setPopupLanguageFormat(static_cast<AppSettings::LanguageFormat>(ui->popupLanguageFormatComboBox->currentIndex()));
@@ -509,6 +515,8 @@ void SettingsDialog::loadSettings()
     ui->popupOpacitySlider->setValue(static_cast<int>(settings.popupOpacity() * 100));
     ui->popupWidthSpinBox->setValue(settings.popupWidth());
     ui->popupHeightSpinBox->setValue(settings.popupHeight());
+
+    ui->translationNotificationDisplayTimeSpinBox->setValue(settings.translationNotificationDisplayTime());
 
     ui->mainWindowLanguageFormatComboBox->setCurrentIndex(settings.mainWindowLanguageFormat());
     ui->popupLanguageFormatComboBox->setCurrentIndex(settings.popupLanguageFormat());

--- a/src/settings/settingsdialog.cpp
+++ b/src/settings/settingsdialog.cpp
@@ -101,6 +101,8 @@ SettingsDialog::SettingsDialog(QWidget *parent)
     // Disable (enable) opacity slider if "Window mode" ("Popup mode") selected
     connect(ui->windowModeComboBox, qOverload<int>(&QComboBox::currentIndexChanged), ui->popupOpacityLabel, &QSlider::setDisabled);
     connect(ui->windowModeComboBox, qOverload<int>(&QComboBox::currentIndexChanged), ui->popupOpacitySlider, &QSlider::setDisabled);
+    
+    // Disable "Show tray icon" if "Pop-up mode selected
     connect(ui->windowModeComboBox, qOverload<int>(&QComboBox::currentIndexChanged), this, &SettingsDialog::setShowTrayIconCheckBoxState);
 
 #ifdef Q_OS_WIN
@@ -244,7 +246,7 @@ void SettingsDialog::processProxyTypeChanged(int type)
     }
 }
 
-// Update "showTrayIconCheckBox" state when “Notification" mode selected
+// Update "Show tray Icon" checkbox state when “Notification" mode selected
 void SettingsDialog::setShowTrayIconCheckBoxState(int index)
 {
     if (index == AppSettings::Notification) {

--- a/src/settings/settingsdialog.cpp
+++ b/src/settings/settingsdialog.cpp
@@ -98,10 +98,6 @@ SettingsDialog::SettingsDialog(QWidget *parent)
     ui->popupHeightSlider->setMinimum(200);
     ui->popupHeightSpinBox->setMinimum(200);
 
-    // Set maximum and minimum values for the time of the translation notification display
-    ui->translationNotificationDisplayTimeSpinBox->setMaximum(60);
-    ui->translationNotificationDisplayTimeSpinBox->setMinimum(1);
-
     // Disable (enable) opacity slider if "Window mode" ("Popup mode") selected
     connect(ui->windowModeComboBox, qOverload<int>(&QComboBox::currentIndexChanged), ui->popupOpacityLabel, &QSlider::setDisabled);
     connect(ui->windowModeComboBox, qOverload<int>(&QComboBox::currentIndexChanged), ui->popupOpacitySlider, &QSlider::setDisabled);
@@ -190,7 +186,7 @@ void SettingsDialog::accept()
     settings.setPopupWidth(ui->popupWidthSpinBox->value());
     settings.setPopupHeight(ui->popupHeightSpinBox->value());
 
-    settings.setTranslationNotificationDisplayTime(ui->translationNotificationDisplayTimeSpinBox->value());
+    settings.setTranslationNotificationTimeout(ui->translationNotificationTimeoutSpinBox->value());
 
     settings.setMainWindowLanguageFormat(static_cast<AppSettings::LanguageFormat>(ui->mainWindowLanguageFormatComboBox->currentIndex()));
     settings.setPopupLanguageFormat(static_cast<AppSettings::LanguageFormat>(ui->popupLanguageFormatComboBox->currentIndex()));
@@ -516,7 +512,7 @@ void SettingsDialog::loadSettings()
     ui->popupWidthSpinBox->setValue(settings.popupWidth());
     ui->popupHeightSpinBox->setValue(settings.popupHeight());
 
-    ui->translationNotificationDisplayTimeSpinBox->setValue(settings.translationNotificationDisplayTime());
+    ui->translationNotificationTimeoutSpinBox->setValue(settings.translationNotificationTimeout());
 
     ui->mainWindowLanguageFormatComboBox->setCurrentIndex(settings.mainWindowLanguageFormat());
     ui->popupLanguageFormatComboBox->setCurrentIndex(settings.popupLanguageFormat());

--- a/src/settings/settingsdialog.cpp
+++ b/src/settings/settingsdialog.cpp
@@ -101,6 +101,7 @@ SettingsDialog::SettingsDialog(QWidget *parent)
     // Disable (enable) opacity slider if "Window mode" ("Popup mode") selected
     connect(ui->windowModeComboBox, qOverload<int>(&QComboBox::currentIndexChanged), ui->popupOpacityLabel, &QSlider::setDisabled);
     connect(ui->windowModeComboBox, qOverload<int>(&QComboBox::currentIndexChanged), ui->popupOpacitySlider, &QSlider::setDisabled);
+    connect(ui->windowModeComboBox, qOverload<int>(&QComboBox::currentIndexChanged), this, &SettingsDialog::setShowTrayIconCheckBoxState);
 
 #ifdef Q_OS_WIN
     // Add information about icons
@@ -240,6 +241,17 @@ void SettingsDialog::processProxyTypeChanged(int type)
         ui->proxyPortSpinbox->setEnabled(false);
         ui->proxyInfoLabel->setEnabled(false);
         ui->proxyAuthCheckBox->setEnabled(false);
+    }
+}
+
+// Update "showTrayIconCheckBox" state when “Notification" mode selected
+void SettingsDialog::setShowTrayIconCheckBoxState(int index)
+{
+    if (index == AppSettings::Notification) {
+        ui->showTrayIconCheckBox->setDisabled(true);
+        ui->showTrayIconCheckBox->setChecked(true);
+    } else {
+        ui->showTrayIconCheckBox->setEnabled(true);
     }
 }
 

--- a/src/settings/settingsdialog.h
+++ b/src/settings/settingsdialog.h
@@ -58,6 +58,7 @@ private slots:
     void processProxyTypeChanged(int type);
     void processTrayIconTypeChanged(int type);
 
+    void setShowTrayIconCheckBoxState(int index);
     void chooseCustomTrayIcon();
     void setCustomTrayIconPreview(const QString &iconPath);
 

--- a/src/settings/settingsdialog.ui
+++ b/src/settings/settingsdialog.ui
@@ -381,16 +381,22 @@
           </property>
           <layout class="QHBoxLayout" name="notificationBoxLayout">
            <item>
-            <widget class="QLabel" name="translationNotificationDisplayTimeLabel">
+            <widget class="QLabel" name="translationNotificationTimeoutLabel">
              <property name="text">
-              <string>Translation notification display time:</string>
+              <string>Translation notification timeout:</string>
              </property>
             </widget>
            </item>
            <item>
-            <widget class="QSpinBox" name="translationNotificationDisplayTimeSpinBox">
+            <widget class="QSpinBox" name="translationNotificationTimeoutSpinBox">
              <property name="suffix">
               <string> s</string>
+             </property>
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <number>60</number>
              </property>
             </widget>
            </item>

--- a/src/settings/settingsdialog.ui
+++ b/src/settings/settingsdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>800</width>
-    <height>552</height>
+    <height>616</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -375,22 +375,22 @@
          </widget>
         </item>
         <item>
-         <widget class="QGroupBox" name="notificationGroupBox">
+         <widget class="QGroupBox" name="translationNotificationGroupBox">
           <property name="title">
            <string>Notification</string>
           </property>
-          <layout class="QHBoxLayout" name="notificationBoxLayout">
-           <item>
+          <layout class="QFormLayout" name="translationNotificationBoxLayout">
+           <item row="0" column="0">
             <widget class="QLabel" name="translationNotificationTimeoutLabel">
              <property name="text">
               <string>Translation notification timeout:</string>
              </property>
             </widget>
            </item>
-           <item>
+           <item row="0" column="1">
             <widget class="QSpinBox" name="translationNotificationTimeoutSpinBox">
              <property name="suffix">
-              <string> s</string>
+              <string> sec</string>
              </property>
              <property name="minimum">
               <number>1</number>
@@ -400,19 +400,6 @@
              </property>
             </widget>
            </item>
-           <item>
-            <spacer name="notificationSpacer">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
           </layout>
          </widget>
         </item>
@@ -421,15 +408,15 @@
           <property name="title">
            <string>Language format</string>
           </property>
-          <layout class="QHBoxLayout" name="languageFormatBoxLayout">
-           <item>
+          <layout class="QFormLayout" name="languageFormatBoxLayout">
+           <item row="0" column="0">
             <widget class="QLabel" name="mainWindowLanguageFormatLabel">
              <property name="text">
               <string>Main window:</string>
              </property>
             </widget>
            </item>
-           <item>
+           <item row="0" column="1">
             <widget class="QComboBox" name="mainWindowLanguageFormatComboBox">
              <item>
               <property name="text">
@@ -443,27 +430,14 @@
              </item>
             </widget>
            </item>
-           <item>
-            <spacer name="languageFormatSpacer">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
+           <item row="1" column="0">
             <widget class="QLabel" name="popupLanguageFormatLabel">
              <property name="text">
               <string>Pop-up:</string>
              </property>
             </widget>
            </item>
-           <item>
+           <item row="1" column="1">
             <widget class="QComboBox" name="popupLanguageFormatComboBox">
              <item>
               <property name="text">
@@ -485,15 +459,35 @@
           <property name="title">
            <string>Tray icon</string>
           </property>
-          <layout class="QHBoxLayout" name="trayIconBoxLayout">
-           <item>
+          <layout class="QGridLayout" name="trayIconBox">
+           <item row="0" column="0">
             <widget class="QLabel" name="trayIconLabel">
              <property name="text">
               <string>Icon:</string>
              </property>
             </widget>
            </item>
-           <item>
+           <item row="1" column="2">
+            <widget class="QToolButton" name="customTrayIconButton">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="customTrayIconLabel">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="text">
+              <string>Custom:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
             <widget class="QComboBox" name="trayIconComboBox">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -542,33 +536,13 @@
              </item>
             </widget>
            </item>
-           <item>
-            <widget class="QLabel" name="customTrayIconLabel">
-             <property name="enabled">
-              <bool>false</bool>
-             </property>
-             <property name="text">
-              <string>Custom:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
+           <item row="1" column="1">
             <widget class="QLineEdit" name="customTrayIconEdit">
              <property name="enabled">
               <bool>false</bool>
              </property>
              <property name="toolTip">
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Path to the icon or icon name from theme&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QToolButton" name="customTrayIconButton">
-             <property name="enabled">
-              <bool>false</bool>
-             </property>
-             <property name="text">
-              <string notr="true"/>
              </property>
             </widget>
            </item>

--- a/src/settings/settingsdialog.ui
+++ b/src/settings/settingsdialog.ui
@@ -243,7 +243,7 @@
           <property name="title">
            <string>Font</string>
           </property>
-          <layout class="QHBoxLayout" name="horizontalLayout">
+          <layout class="QHBoxLayout" name="fontBoxLayout">
            <item>
             <widget class="QLabel" name="fontNameLabel">
              <property name="text">
@@ -375,22 +375,55 @@
          </widget>
         </item>
         <item>
+         <widget class="QGroupBox" name="notificationGroupBox">
+          <property name="title">
+           <string>Notification</string>
+          </property>
+          <layout class="QHBoxLayout" name="notificationBoxLayout">
+           <item>
+            <widget class="QLabel" name="translationNotificationDisplayTimeLabel">
+             <property name="text">
+              <string>Translation notification display time:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QSpinBox" name="translationNotificationDisplayTimeSpinBox">
+             <property name="suffix">
+              <string> s</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="notificationSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
          <widget class="QGroupBox" name="languageFormatGroupBox">
           <property name="title">
            <string>Language format</string>
           </property>
-          <layout class="QFormLayout" name="formLayout">
-           <property name="labelAlignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-           </property>
-           <item row="0" column="0">
+          <layout class="QHBoxLayout" name="languageFormatBoxLayout">
+           <item>
             <widget class="QLabel" name="mainWindowLanguageFormatLabel">
              <property name="text">
               <string>Main window:</string>
              </property>
             </widget>
            </item>
-           <item row="0" column="1">
+           <item>
             <widget class="QComboBox" name="mainWindowLanguageFormatComboBox">
              <item>
               <property name="text">
@@ -404,14 +437,27 @@
              </item>
             </widget>
            </item>
-           <item row="1" column="0">
+           <item>
+            <spacer name="languageFormatSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
             <widget class="QLabel" name="popupLanguageFormatLabel">
              <property name="text">
               <string>Pop-up:</string>
              </property>
             </widget>
            </item>
-           <item row="1" column="1">
+           <item>
             <widget class="QComboBox" name="popupLanguageFormatComboBox">
              <item>
               <property name="text">
@@ -433,35 +479,15 @@
           <property name="title">
            <string>Tray icon</string>
           </property>
-          <layout class="QGridLayout" name="trayIconBox">
-           <item row="0" column="0">
+          <layout class="QHBoxLayout" name="trayIconBoxLayout">
+           <item>
             <widget class="QLabel" name="trayIconLabel">
              <property name="text">
               <string>Icon:</string>
              </property>
             </widget>
            </item>
-           <item row="1" column="2">
-            <widget class="QToolButton" name="customTrayIconButton">
-             <property name="enabled">
-              <bool>false</bool>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="customTrayIconLabel">
-             <property name="enabled">
-              <bool>false</bool>
-             </property>
-             <property name="text">
-              <string>Custom:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
+           <item>
             <widget class="QComboBox" name="trayIconComboBox">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -510,13 +536,33 @@
              </item>
             </widget>
            </item>
-           <item row="1" column="1">
+           <item>
+            <widget class="QLabel" name="customTrayIconLabel">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="text">
+              <string>Custom:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
             <widget class="QLineEdit" name="customTrayIconEdit">
              <property name="enabled">
               <bool>false</bool>
              </property>
              <property name="toolTip">
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Path to the icon or icon name from theme&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QToolButton" name="customTrayIconButton">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="text">
+              <string notr="true"/>
              </property>
             </widget>
            </item>

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -47,6 +47,8 @@ void TrayIcon::loadSettings(const AppSettings &settings)
         setIcon(QIcon::fromTheme(trayIconName(iconType)));
     }
 
+    setTranslationNotificationTimeout(settings.translationNotificationTimeout());
+
     const bool trayIconVisible = settings.isShowTrayIcon();
     setVisible(trayIconVisible);
     QGuiApplication::setQuitOnLastWindowClosed(!trayIconVisible);
@@ -74,6 +76,21 @@ QString TrayIcon::trayIconName(TrayIcon::IconType type)
     default:
         return QString();
     }
+}
+
+void TrayIcon::showTranslationMessage(const QString &message)
+{
+    showMessage(tr("Translation Result"), message, QSystemTrayIcon::NoIcon, translationNotificationTimeout()*1000);
+}
+
+int TrayIcon::translationNotificationTimeout()
+{
+    return m_translationNotificaitonTimeout;
+}
+
+void TrayIcon::setTranslationNotificationTimeout(int timeout)
+{
+    m_translationNotificaitonTimeout = timeout;
 }
 
 void TrayIcon::processTrayActivated(QSystemTrayIcon::ActivationReason reason)

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -47,7 +47,7 @@ void TrayIcon::loadSettings(const AppSettings &settings)
         setIcon(QIcon::fromTheme(trayIconName(iconType)));
     }
 
-    setTranslationNotificationTimeout(settings.translationNotificationTimeout());
+    m_translationNotificaitonTimeout = settings.translationNotificationTimeout();
 
     const bool trayIconVisible = settings.isShowTrayIcon();
     setVisible(trayIconVisible);
@@ -80,17 +80,7 @@ QString TrayIcon::trayIconName(TrayIcon::IconType type)
 
 void TrayIcon::showTranslationMessage(const QString &message)
 {
-    showMessage(tr("Translation Result"), message, QSystemTrayIcon::NoIcon, translationNotificationTimeout()*1000);
-}
-
-int TrayIcon::translationNotificationTimeout()
-{
-    return m_translationNotificaitonTimeout;
-}
-
-void TrayIcon::setTranslationNotificationTimeout(int timeout)
-{
-    m_translationNotificaitonTimeout = timeout;
+    showMessage(tr("Translation Result"), message, QSystemTrayIcon::NoIcon, m_translationNotificaitonTimeout * 1000);
 }
 
 void TrayIcon::processTrayActivated(QSystemTrayIcon::ActivationReason reason)

--- a/src/trayicon.h
+++ b/src/trayicon.h
@@ -47,8 +47,15 @@ public:
     static QIcon customTrayIcon(const QString &customName);
     static QString trayIconName(IconType type);
 
+    void showTranslationMessage(const QString &message);
+    int translationNotificationTimeout();
+    void setTranslationNotificationTimeout(int timeout);
+
 private slots:
     void processTrayActivated(QSystemTrayIcon::ActivationReason reason);
+
+private:
+    int m_translationNotificaitonTimeout;
 };
 
 #endif // TRAYICON_H

--- a/src/trayicon.h
+++ b/src/trayicon.h
@@ -48,8 +48,6 @@ public:
     static QString trayIconName(IconType type);
 
     void showTranslationMessage(const QString &message);
-    int translationNotificationTimeout();
-    void setTranslationNotificationTimeout(int timeout);
 
 private slots:
     void processTrayActivated(QSystemTrayIcon::ActivationReason reason);


### PR DESCRIPTION
I have implemented the setting of `translation notification display time`. I changed the page layout in `Setting -> Interface`. If you are not satisfied, you can adjust it or give me feedback. I don't know about the update operation of  `.ts` files so I leaved them to you. I'm very glad to be able to help with this project :).