### PR TITLE
Improve OCR

### DIFF
--- a/src/ocr/ocr.cpp
+++ b/src/ocr/ocr.cpp
@@ -25,7 +25,9 @@
 #include <QPixmap>
 #include <QtConcurrent>
 
+#if TESSERACT_MAJOR_VERSION < 5
 #include <tesseract/genericvector.h>
+#endif
 
 Ocr::Ocr(QObject *parent)
     : QObject(parent)
@@ -40,11 +42,19 @@ Ocr::Ocr(QObject *parent)
 QStringList Ocr::availableLanguages() const
 {
     QStringList availableLanguages;
+#if TESSERACT_MAJOR_VERSION < 5
     GenericVector<STRING> languages;
+#else
+    std::vector<std::string> languages;
+#endif
     m_tesseract.GetAvailableLanguagesAsVector(&languages);
     availableLanguages.reserve(languages.size());
     for (int i = 0; i < languages.size(); ++i)
+#if TESSERACT_MAJOR_VERSION < 5
         availableLanguages.append(languages[i].string());
+#else
+        availableLanguages.append(QString::fromStdString(languages[i]));
+#endif
     return availableLanguages;
 }
 

--- a/src/ocr/ocr.h
+++ b/src/ocr/ocr.h
@@ -54,7 +54,11 @@ private:
 
     QFuture<void> m_future;
     tesseract::TessBaseAPI m_tesseract;
+#if TESSERACT_MAJOR_VERSION < 5
     ETEXT_DESC m_monitor;
+#else
+    tesseract::ETEXT_DESC m_monitor;
+#endif
 };
 
 #endif // OCR_H

--- a/src/settings/settingsdialog.cpp
+++ b/src/settings/settingsdialog.cpp
@@ -570,7 +570,6 @@ void SettingsDialog::loadSettings()
     ui->customTrayIconEdit->setText(settings.customIconPath());
 
     // Translation settings
-    ui->convertLineBreaksCheckBox->setChecked(settings.isConvertLineBreaks());
     ui->sourceTranslitCheckBox->setChecked(settings.isSourceTranslitEnabled());
     ui->translationTranslitCheckBox->setChecked(settings.isTranslationTranslitEnabled());
     ui->sourceTranscriptionCheckBox->setChecked(settings.isSourceTranscriptionEnabled());
@@ -583,6 +582,7 @@ void SettingsDialog::loadSettings()
     ui->forceTranslationAutoCheckBox->setChecked(settings.isForceTranslationAutodetect());
 
     // OCR
+    ui->convertLineBreaksCheckBox->setChecked(settings.isConvertLineBreaks());
     ui->ocrLanguagesPathEdit->setText(settings.ocrLanguagesPath());
     ui->ocrLanguagesListWidget->setCheckedLanguages(settings.ocrLanguagesString());
     ui->rememberRegionComboBox->setCurrentIndex(settings.regionRememberType());


### PR DESCRIPTION
The first commit makes tesseract read from a config file. The following parameters are of particular interest for CJK languages, especially when written vertically. Unfortunately automatic script and orientation detection is only supported by the legacy engine. The newer LSTM models usually give better results but require manually specifying the orientation.

```ini
# Tells tesseract whether the script is horizontal (6) or vertical (5)
tessedit_pageseg_mode
# Don't add spaces between characters
preserve_interword_spaces
# toggling these options on or off may improve the output in some circumstances
paragraph_text_based
textord_old_baselines
lstm_use_matrix
```

I've been experimenting with the in development tesseract v5 on my system, so the second commit makes crow compile with it. The v5 API is still very much a moving target, so you might prefer to wait for a stable release first. That being said, it isn't too bad since crowing is only using a small subset of the API.

Thoughts?