### PR TITLE
Tesseract parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,7 @@ add_executable(${PROJECT_NAME}
     src/settings/ocrlanguageslistwidget.cpp
     src/settings/settingsdialog.cpp
     src/settings/settingsdialog.ui
+    src/settings/tesseractparameterstablewidget.cpp
     src/settings/shortcutsmodel/shortcutitem.cpp
     src/settings/shortcutsmodel/shortcutsmodel.cpp
     src/settings/shortcutsmodel/shortcutsview.cpp

--- a/src/ocr/ocr.cpp
+++ b/src/ocr/ocr.cpp
@@ -85,9 +85,8 @@ void Ocr::recognize(const QPixmap &pixmap, int dpi)
         m_tesseract.SetSourceResolution(dpi);
         QMap<QString, QVariant> parameters = AppSettings().tesseractParameters();
         for (auto it = parameters.cbegin(); it != parameters.cend(); ++it) {
-            if (!m_tesseract.SetVariable(qPrintable(it.key()), qPrintable(it.value().toString()))) {
+            if (!m_tesseract.SetVariable(it.key().toLocal8Bit(), it.value().toByteArray()))
                 qWarning() << tr("%1 is not the name of a valid tesseract parameter.").arg(it.key());
-            }
         }
         m_tesseract.Recognize(&m_monitor);
         if (m_future.isCanceled()) {

--- a/src/ocr/ocr.cpp
+++ b/src/ocr/ocr.cpp
@@ -83,6 +83,12 @@ void Ocr::recognize(const QPixmap &pixmap, int dpi)
     m_future = QtConcurrent::run([this, dpi, image = pixmap.toImage()] {
         m_tesseract.SetImage(image.constBits(), image.width(), image.height(), image.depth() / 8, image.bytesPerLine());
         m_tesseract.SetSourceResolution(dpi);
+        QMap<QString, QVariant> parameters = AppSettings().tesseractParameters();
+        for (auto it = parameters.cbegin(); it != parameters.cend(); ++it) {
+            if (!m_tesseract.SetVariable(qPrintable(it.key()), qPrintable(it.value().toString()))) {
+                qWarning() << tr("%1 is not the name of a valid tesseract parameter.").arg(it.key());
+            }
+        }
         m_tesseract.Recognize(&m_monitor);
         if (m_future.isCanceled()) {
             emit canceled();

--- a/src/settings/appsettings.cpp
+++ b/src/settings/appsettings.cpp
@@ -990,10 +990,8 @@ QMap<QString, QVariant> AppSettings::tesseractParameters() const
 {
     QMap<QString, QVariant> parameters;
     m_settings->beginGroup("Tesseract");
-    QStringList keys = m_settings->childKeys();
-    for (const auto &key : keys) {
+    for (const QString &key : m_settings->childKeys())
         parameters.insert(key, m_settings->value(key));
-    }
     m_settings->endGroup();
     return parameters;
 }
@@ -1002,15 +1000,14 @@ void AppSettings::setTesseractParameters(const QMap<QString, QVariant> &paramete
 {
     m_settings->beginGroup("Tesseract");
     m_settings->remove("");
-    for (auto it = parameters.cbegin(); it != parameters.cend(); ++it) {
+    for (auto it = parameters.cbegin(); it != parameters.cend(); ++it)
         m_settings->setValue(it.key(), it.value());
-    }
     m_settings->endGroup();
 }
 
 QMap<QString, QVariant> AppSettings::defaultTesseractParameters()
 {
-    return QMap<QString, QVariant>();
+    return {};
 }
 
 bool AppSettings::isCaptureOnRelease() const

--- a/src/settings/appsettings.cpp
+++ b/src/settings/appsettings.cpp
@@ -998,11 +998,19 @@ QMap<QString, QVariant> AppSettings::tesseractParameters() const
     return parameters;
 }
 
-void AppSettings::setTesseractParameter(const QString key, const QVariant value)
+void AppSettings::setTesseractParameters(const QMap<QString, QVariant> &parameters)
 {
     m_settings->beginGroup("Tesseract");
-    m_settings->setValue(key, value);
+    m_settings->remove("");
+    for (auto it = parameters.cbegin(); it != parameters.cend(); ++it) {
+        m_settings->setValue(it.key(), it.value());
+    }
     m_settings->endGroup();
+}
+
+QMap<QString, QVariant> AppSettings::defaultTesseractParameters()
+{
+    return QMap<QString, QVariant>();
 }
 
 bool AppSettings::isCaptureOnRelease() const

--- a/src/settings/appsettings.cpp
+++ b/src/settings/appsettings.cpp
@@ -999,7 +999,7 @@ QMap<QString, QVariant> AppSettings::tesseractParameters() const
 void AppSettings::setTesseractParameters(const QMap<QString, QVariant> &parameters)
 {
     m_settings->beginGroup("Tesseract");
-    m_settings->remove("");
+    m_settings->remove({}); // Remove all keys in current group
     for (auto it = parameters.cbegin(); it != parameters.cend(); ++it)
         m_settings->setValue(it.key(), it.value());
     m_settings->endGroup();

--- a/src/settings/appsettings.cpp
+++ b/src/settings/appsettings.cpp
@@ -986,6 +986,25 @@ bool AppSettings::defaultShowMagnifier()
     return false;
 }
 
+QMap<QString, QVariant> AppSettings::tesseractParameters() const
+{
+    QMap<QString, QVariant> parameters;
+    m_settings->beginGroup("Tesseract");
+    QStringList keys = m_settings->childKeys();
+    for (const auto &key : keys) {
+        parameters.insert(key, m_settings->value(key));
+    }
+    m_settings->endGroup();
+    return parameters;
+}
+
+void AppSettings::setTesseractParameter(const QString key, const QVariant value)
+{
+    m_settings->beginGroup("Tesseract");
+    m_settings->setValue(key, value);
+    m_settings->endGroup();
+}
+
 bool AppSettings::isCaptureOnRelease() const
 {
     return m_settings->value(QStringLiteral("OCR/CaptureOnRelease"), defaultCaptureOnRelease()).toBool();

--- a/src/settings/appsettings.h
+++ b/src/settings/appsettings.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  *  Copyright © 2018-2021 Hennadii Chernyshchyk <genaloner@gmail.com>
  *
  *  This file is part of Crow Translate.
@@ -306,6 +306,9 @@ public:
     QByteArray ocrLanguagesString() const;
     void setOcrLanguagesString(const QByteArray &string);
     static QByteArray defaultOcrLanguagesString();
+
+    QMap<QString, QVariant> tesseractParameters() const;
+    void setTesseractParameter(const QString key, const QVariant value);
 
     bool isShowMagnifier() const;
     void setShowMagnifier(bool show);

--- a/src/settings/appsettings.h
+++ b/src/settings/appsettings.h
@@ -308,7 +308,8 @@ public:
     static QByteArray defaultOcrLanguagesString();
 
     QMap<QString, QVariant> tesseractParameters() const;
-    void setTesseractParameter(const QString key, const QVariant value);
+    void setTesseractParameters(const QMap<QString, QVariant> &parameters);
+    static QMap<QString, QVariant> defaultTesseractParameters();
 
     bool isShowMagnifier() const;
     void setShowMagnifier(bool show);

--- a/src/settings/settingsdialog.cpp
+++ b/src/settings/settingsdialog.cpp
@@ -311,6 +311,30 @@ void SettingsDialog::onOcrLanguagesPathChanged(const QString &path)
     ui->ocrLanguagesListWidget->addLanguages(Ocr::availableLanguages(path));
 }
 
+void SettingsDialog::onTesseractParametersCurrentItemChanged()
+{
+    if (ui->tesseractParametersTableWidget->currentRow() == -1) {
+        ui->tesseractParametersRemoveButton->setEnabled(false);
+    } else {
+        ui->tesseractParametersRemoveButton->setEnabled(true);
+    }
+}
+
+void SettingsDialog::onTesseractParametersAdd()
+{
+    ui->tesseractParametersTableWidget->addParameter();
+    int lastRow = ui->tesseractParametersTableWidget->rowCount() - 1;
+    QTableWidgetItem *newCell = ui->tesseractParametersTableWidget->item(lastRow, 0);
+    ui->tesseractParametersTableWidget->setCurrentItem(newCell);
+    ui->tesseractParametersTableWidget->editItem(newCell);
+}
+
+void SettingsDialog::onTesseractParametersRemove()
+{
+    int row = ui->tesseractParametersTableWidget->currentRow();
+    ui->tesseractParametersTableWidget->removeRow(row);
+}
+
 // Disable unsupported voice settings for engines.
 void SettingsDialog::showAvailableTtsOptions(int engine)
 {

--- a/src/settings/settingsdialog.cpp
+++ b/src/settings/settingsdialog.cpp
@@ -165,6 +165,22 @@ SettingsDialog::~SettingsDialog()
 
 void SettingsDialog::accept()
 {
+    if (!ui->tesseractParametersTableWidget->validateParameters()) {
+        QMessageBox msgBox;
+        msgBox.setText(tr("The OCR parameter fields may not be empty."));
+        msgBox.setInformativeText(tr("Do you want to discard the invalid parameters?"));
+        msgBox.setStandardButtons(QMessageBox::No | QMessageBox::Yes);
+        msgBox.setDefaultButton(QMessageBox::No);
+        msgBox.setIcon(QMessageBox::Warning);
+        if (msgBox.exec() == QMessageBox::No) {
+            auto *ocrPage = ui->pagesStackedWidget->findChild<QWidget *>("ocrPage");
+            int n = ui->pagesStackedWidget->indexOf(ocrPage);
+            ui->pagesStackedWidget->setCurrentIndex(n);
+            ui->pagesListWidget->setCurrentRow(n);
+            return;
+        }
+    }
+
     QDialog::accept();
 
     // Set settings location first

--- a/src/settings/settingsdialog.cpp
+++ b/src/settings/settingsdialog.cpp
@@ -167,16 +167,15 @@ void SettingsDialog::accept()
 {
     if (!ui->tesseractParametersTableWidget->validateParameters()) {
         QMessageBox msgBox;
-        msgBox.setText(tr("The OCR parameter fields may not be empty."));
+        msgBox.setText(tr("The OCR parameter fields can not be empty."));
         msgBox.setInformativeText(tr("Do you want to discard the invalid parameters?"));
         msgBox.setStandardButtons(QMessageBox::No | QMessageBox::Yes);
         msgBox.setDefaultButton(QMessageBox::No);
         msgBox.setIcon(QMessageBox::Warning);
         if (msgBox.exec() == QMessageBox::No) {
-            auto *ocrPage = ui->pagesStackedWidget->findChild<QWidget *>("ocrPage");
-            int n = ui->pagesStackedWidget->indexOf(ocrPage);
-            ui->pagesStackedWidget->setCurrentIndex(n);
-            ui->pagesListWidget->setCurrentRow(n);
+            const int pageIndex = ui->pagesStackedWidget->indexOf(ui->ocrPage);
+            ui->pagesStackedWidget->setCurrentIndex(pageIndex);
+            ui->pagesListWidget->setCurrentRow(pageIndex);
             return;
         }
     }
@@ -329,11 +328,10 @@ void SettingsDialog::onOcrLanguagesPathChanged(const QString &path)
 
 void SettingsDialog::onTesseractParametersCurrentItemChanged()
 {
-    if (ui->tesseractParametersTableWidget->currentRow() == -1) {
+    if (ui->tesseractParametersTableWidget->currentRow() == -1)
         ui->tesseractParametersRemoveButton->setEnabled(false);
-    } else {
+    else
         ui->tesseractParametersRemoveButton->setEnabled(true);
-    }
 }
 
 void SettingsDialog::onTesseractParametersAdd()

--- a/src/settings/settingsdialog.cpp
+++ b/src/settings/settingsdialog.cpp
@@ -334,21 +334,6 @@ void SettingsDialog::onTesseractParametersCurrentItemChanged()
         ui->tesseractParametersRemoveButton->setEnabled(true);
 }
 
-void SettingsDialog::onTesseractParametersAdd()
-{
-    ui->tesseractParametersTableWidget->addParameter();
-    int lastRow = ui->tesseractParametersTableWidget->rowCount() - 1;
-    QTableWidgetItem *newCell = ui->tesseractParametersTableWidget->item(lastRow, 0);
-    ui->tesseractParametersTableWidget->setCurrentItem(newCell);
-    ui->tesseractParametersTableWidget->editItem(newCell);
-}
-
-void SettingsDialog::onTesseractParametersRemove()
-{
-    int row = ui->tesseractParametersTableWidget->currentRow();
-    ui->tesseractParametersTableWidget->removeRow(row);
-}
-
 // Disable unsupported voice settings for engines.
 void SettingsDialog::showAvailableTtsOptions(int engine)
 {

--- a/src/settings/settingsdialog.cpp
+++ b/src/settings/settingsdialog.cpp
@@ -220,6 +220,7 @@ void SettingsDialog::accept()
     settings.setShowMagnifier(ui->showMagnifierCheckBox->isChecked());
     settings.setCaptureOnRelease(ui->captureOnReleaseCheckBox->isChecked());
     settings.setApplyLightMask(ui->applyLightMaskCheckBox->isChecked());
+    settings.setTesseractParameters(ui->tesseractParametersTableWidget->parameters());
 
     // Speech synthesis settings
     settings.setVoice(QOnlineTranslator::Yandex, ui->playerButtons->voice(QOnlineTranslator::Yandex));
@@ -517,6 +518,7 @@ void SettingsDialog::restoreDefaults()
     ui->showMagnifierCheckBox->setChecked(AppSettings::defaultShowMagnifier());
     ui->captureOnReleaseCheckBox->setChecked(AppSettings::defaultCaptureOnRelease());
     ui->applyLightMaskCheckBox->setChecked(AppSettings::defaultApplyLightMask());
+    ui->tesseractParametersTableWidget->setParameters(AppSettings::defaultTesseractParameters());
 
     // Speech synthesis settings
     ui->playerButtons->setVoice(QOnlineTranslator::Yandex, AppSettings::defaultVoice(QOnlineTranslator::Yandex));
@@ -589,6 +591,7 @@ void SettingsDialog::loadSettings()
     ui->showMagnifierCheckBox->setChecked(settings.isShowMagnifier());
     ui->captureOnReleaseCheckBox->setChecked(settings.isCaptureOnRelease());
     ui->applyLightMaskCheckBox->setChecked(settings.isApplyLightMask());
+    ui->tesseractParametersTableWidget->setParameters(settings.tesseractParameters());
 
     // Speech synthesis settings
     ui->playerButtons->setVoice(QOnlineTranslator::Yandex, settings.voice(QOnlineTranslator::Yandex));

--- a/src/settings/settingsdialog.h
+++ b/src/settings/settingsdialog.h
@@ -65,6 +65,9 @@ private slots:
 
     void selectOcrLanguagesPath();
     void onOcrLanguagesPathChanged(const QString &path);
+    void onTesseractParametersCurrentItemChanged();
+    void onTesseractParametersAdd();
+    void onTesseractParametersRemove();
 
     void showAvailableTtsOptions(int engine);
     void saveEngineVoice(int voice);

--- a/src/settings/settingsdialog.h
+++ b/src/settings/settingsdialog.h
@@ -66,8 +66,6 @@ private slots:
     void selectOcrLanguagesPath();
     void onOcrLanguagesPathChanged(const QString &path);
     void onTesseractParametersCurrentItemChanged();
-    void onTesseractParametersAdd();
-    void onTesseractParametersRemove();
 
     void showAvailableTtsOptions(int engine);
     void saveEngineVoice(int voice);

--- a/src/settings/settingsdialog.ui
+++ b/src/settings/settingsdialog.ui
@@ -784,8 +784,8 @@
           <property name="title">
            <string notr="true">OCR</string>
           </property>
-          <layout class="QGridLayout" name="ocrParametersLayout">
-           <item row="0" column="0" colspan="3">
+          <layout class="QVBoxLayout" name="ocrParametersLayout">
+           <item>
             <widget class="QCheckBox" name="convertLineBreaksCheckBox">
              <property name="toolTip">
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Replace all single line breaks with a space after text recognition&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -795,8 +795,50 @@
              </property>
             </widget>
            </item>
-           <item row="1" column="0" colspan="3">
-            <widget class="TesseractParametersTableWidget" name="tesseractParametersTableWidget"></widget>
+           <item>
+            <layout class="QHBoxLayout" name="tesseractParametersTableHorizontalLayout">
+             <item>
+              <layout class="QVBoxLayout" name="tesseractParametersButtonsVerticalLayout">
+               <item>
+                <spacer name="tesseractParametersButtonsVerticalSpacer1">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                </spacer>
+               </item>
+               <item>
+                <widget class="QToolButton" name="tesseractParametersAddButton">
+                 <property name="icon">
+                  <iconset theme="list-add">
+                   <normaloff>.</normaloff>.</iconset>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QToolButton" name="tesseractParametersRemoveButton">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="icon">
+                  <iconset theme="list-remove">
+                   <normaloff>.</normaloff>.</iconset>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="tesseractParametersButtonsVerticalSpacer2">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <widget class="TesseractParametersTableWidget" name="tesseractParametersTableWidget">
+              </widget>
+             </item>
+            </layout>
            </item>
           </layout>
          </widget>
@@ -2065,6 +2107,54 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>tesseractParametersAddButton</sender>
+   <signal>clicked()</signal>
+   <receiver>SettingsDialog</receiver>
+   <slot>onTesseractParametersAdd()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>701</x>
+     <y>344</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>667</x>
+     <y>-19</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>tesseractParametersRemoveButton</sender>
+   <signal>clicked()</signal>
+   <receiver>SettingsDialog</receiver>
+   <slot>onTesseractParametersRemove()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>701</x>
+     <y>344</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>667</x>
+     <y>-19</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>tesseractParametersTableWidget</sender>
+   <signal>currentItemChanged(QTableWidgetItem*, QTableWidgetItem*)</signal>
+   <receiver>SettingsDialog</receiver>
+   <slot>onTesseractParametersCurrentItemChanged()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>701</x>
+     <y>344</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>667</x>
+     <y>-19</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
  <slots>
   <slot>onProxyTypeChanged(int)</slot>
@@ -2084,5 +2174,8 @@
   <slot>selectOcrLanguagesPath()</slot>
   <slot>onOcrLanguagesPathChanged(QString)</slot>
   <slot>onWindowModeChanged(int)</slot>
+  <slot>onTesseractParametersAdd()</slot>
+  <slot>onTesseractParametersRemove()</slot>
+  <slot>onTesseractParametersCurrentItemChanged()</slot>
  </slots>
 </ui>

--- a/src/settings/settingsdialog.ui
+++ b/src/settings/settingsdialog.ui
@@ -725,37 +725,38 @@
       <widget class="QWidget" name="ocrPage">
        <layout class="QVBoxLayout" name="ocrLayout">
         <item>
-         <widget class="QGroupBox" name="ocrGroupBox">
+         <widget class="QGroupBox" name="languagesGroupBox">
           <property name="title">
-           <string notr="true">OCR</string>
+           <string>Languages</string>
           </property>
           <layout class="QGridLayout" name="ocrLanguagesLayout">
-           <item row="3" column="0" colspan="3">
+           <item row="1" column="0" colspan="3">
             <widget class="OcrLanguagesListWidget" name="ocrLanguagesListWidget">
              <property name="toolTip">
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Loading additional languages will impact both speed and accuracy, as there is more work to do to decide on the applicable language, and there is more chance of hallucinating incorrect words.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
             </widget>
            </item>
-           <item row="1" column="0">
+           <item row="0" column="0">
             <widget class="QLabel" name="ocrLanguagesPathLabel">
              <property name="text">
               <string>Languages path:</string>
              </property>
             </widget>
            </item>
-           <item row="1" column="2">
+           <item row="0" column="2">
             <widget class="QToolButton" name="ocrLanguagesPathButton">
              <property name="toolTip">
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select OCR languages path&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <property name="icon">
               <iconset theme="folder">
-               <normaloff>.</normaloff>.</iconset>
+               <normaloff>.</normaloff>.
+              </iconset>
              </property>
             </widget>
            </item>
-           <item row="4" column="0">
+           <item row="2" column="0">
             <widget class="QLabel" name="downloadMoreLabel">
              <property name="toolTip">
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open GitHub repository&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -768,13 +769,22 @@
              </property>
             </widget>
            </item>
-           <item row="1" column="1">
+           <item row="0" column="1">
             <widget class="QLineEdit" name="ocrLanguagesPathEdit">
              <property name="placeholderText">
               <string>Directory with trained models</string>
              </property>
             </widget>
            </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="ocrParametersGroupBox">
+          <property name="title">
+           <string notr="true">OCR</string>
+          </property>
+          <layout class="QGridLayout" name="ocrParametersLayout">
            <item row="0" column="0" colspan="3">
             <widget class="QCheckBox" name="convertLineBreaksCheckBox">
              <property name="toolTip">
@@ -784,6 +794,9 @@
               <string>Convert line breaks</string>
              </property>
             </widget>
+           </item>
+           <item row="1" column="0" colspan="3">
+            <widget class="TesseractParametersTableWidget" name="tesseractParametersTableWidget"></widget>
            </item>
           </layout>
          </widget>
@@ -1513,6 +1526,11 @@
    <class>OcrLanguagesListWidget</class>
    <extends>QListWidget</extends>
    <header>settings/ocrlanguageslistwidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>TesseractParametersTableWidget</class>
+   <extends>QTableWidget</extends>
+   <header>settings/tesseractparameterstablewidget.h</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/src/settings/settingsdialog.ui
+++ b/src/settings/settingsdialog.ui
@@ -2110,8 +2110,8 @@
   <connection>
    <sender>tesseractParametersAddButton</sender>
    <signal>clicked()</signal>
-   <receiver>SettingsDialog</receiver>
-   <slot>onTesseractParametersAdd()</slot>
+   <receiver>tesseractParametersTableWidget</receiver>
+   <slot>addParameter()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>701</x>
@@ -2126,8 +2126,8 @@
   <connection>
    <sender>tesseractParametersRemoveButton</sender>
    <signal>clicked()</signal>
-   <receiver>SettingsDialog</receiver>
-   <slot>onTesseractParametersRemove()</slot>
+   <receiver>tesseractParametersTableWidget</receiver>
+   <slot>removeCurrent()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>701</x>
@@ -2174,8 +2174,8 @@
   <slot>selectOcrLanguagesPath()</slot>
   <slot>onOcrLanguagesPathChanged(QString)</slot>
   <slot>onWindowModeChanged(int)</slot>
-  <slot>onTesseractParametersAdd()</slot>
-  <slot>onTesseractParametersRemove()</slot>
+  <slot>addParameter()</slot>
+  <slot>removeCurrent()</slot>
   <slot>onTesseractParametersCurrentItemChanged()</slot>
  </slots>
 </ui>

--- a/src/settings/tesseractparameterstablewidget.cpp
+++ b/src/settings/tesseractparameterstablewidget.cpp
@@ -38,6 +38,8 @@ void TesseractParametersTableWidget::addParameter(const QString &key, const QVar
     insertRow(rowCount());
     setItem(rowCount() - 1, 0, keyWidget);
     setItem(rowCount() - 1, 1, valueWidget);
+    setCurrentItem(keyWidget);
+    editItem(keyWidget);
 }
 
 void TesseractParametersTableWidget::setParameters(const QMap<QString, QVariant> &parameters)
@@ -46,6 +48,7 @@ void TesseractParametersTableWidget::setParameters(const QMap<QString, QVariant>
     setRowCount(0);
     for (auto it = parameters.cbegin(); it != parameters.cend(); ++it)
         addParameter(it.key(), it.value());
+    setCurrentItem(nullptr);
 }
 
 QMap<QString, QVariant> TesseractParametersTableWidget::parameters()
@@ -58,6 +61,11 @@ QMap<QString, QVariant> TesseractParametersTableWidget::parameters()
         parameters.insert(key, value);
     }
     return parameters;
+}
+
+void TesseractParametersTableWidget::removeCurrent()
+{
+    removeRow(currentRow());
 }
 
 // Return false if any key is missing a value or vice versa. Also focus the empty cell.

--- a/src/settings/tesseractparameterstablewidget.cpp
+++ b/src/settings/tesseractparameterstablewidget.cpp
@@ -20,14 +20,13 @@
 
 #include "tesseractparameterstablewidget.h"
 
-#include <QLineEdit>
 #include <QHeaderView>
 
 TesseractParametersTableWidget::TesseractParametersTableWidget(QWidget *parent)
     : QTableWidget(parent)
 {
     setColumnCount(2);
-    setHorizontalHeaderLabels({ tr("Property"), tr("Value") });
+    setHorizontalHeaderLabels({tr("Property"), tr("Value")});
     horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
     verticalHeader()->setVisible(false);
 }
@@ -41,18 +40,12 @@ void TesseractParametersTableWidget::addParameter(const QString &key, const QVar
     setItem(rowCount() - 1, 1, valueWidget);
 }
 
-void TesseractParametersTableWidget::addParameter()
-{
-    addParameter("", "");
-}
-
 void TesseractParametersTableWidget::setParameters(const QMap<QString, QVariant> &parameters)
 {
     clearContents();
     setRowCount(0);
-    for (auto it = parameters.cbegin(); it != parameters.cend(); ++it) {
+    for (auto it = parameters.cbegin(); it != parameters.cend(); ++it)
         addParameter(it.key(), it.value());
-    }
 }
 
 QMap<QString, QVariant> TesseractParametersTableWidget::parameters()
@@ -60,8 +53,8 @@ QMap<QString, QVariant> TesseractParametersTableWidget::parameters()
     removeInvalidParameters();
     QMap<QString, QVariant> parameters;
     for (int i = 0; i < rowCount(); ++i) {
-        QString key = item(i, 0)->text();
-        auto value = QVariant(item(i, 1)->text());
+        const QString key = item(i, 0)->text();
+        const QVariant value = item(i, 1)->text();
         parameters.insert(key, value);
     }
     return parameters;
@@ -70,8 +63,7 @@ QMap<QString, QVariant> TesseractParametersTableWidget::parameters()
 // Return false if any key is missing a value or vice versa. Also focus the empty cell.
 bool TesseractParametersTableWidget::validateParameters()
 {
-    for (int i = 0; i < rowCount(); ++i)
-    {
+    for (int i = 0; i < rowCount(); ++i) {
         QTableWidgetItem *key = item(i, 0);
         QTableWidgetItem *value = item(i, 1);
         if (key->text().isEmpty() && !value->text().isEmpty()) {
@@ -92,8 +84,8 @@ bool TesseractParametersTableWidget::validateParameters()
 void TesseractParametersTableWidget::removeInvalidParameters()
 {
     for (int i = rowCount() - 1; i >= 0; --i) {
-        QTableWidgetItem *key = item(i, 0);
-        QTableWidgetItem *value = item(i, 1);
+        const QTableWidgetItem *key = item(i, 0);
+        const QTableWidgetItem *value = item(i, 1);
         if (key->text().isEmpty() || value->text().isEmpty()) {
             removeRow(i);
         }

--- a/src/settings/tesseractparameterstablewidget.cpp
+++ b/src/settings/tesseractparameterstablewidget.cpp
@@ -1,0 +1,68 @@
+/*
+ *  Copyright © 2018-2021 Hennadii Chernyshchyk <genaloner@gmail.com>
+ *
+ *  This file is part of Crow Translate.
+ *
+ *  Crow Translate is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Crow Translate is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a get of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "tesseractparameterstablewidget.h"
+
+#include <QLineEdit>
+#include <QHeaderView>
+
+TesseractParametersTableWidget::TesseractParametersTableWidget(QWidget *parent)
+    : QTableWidget(parent)
+{
+    setColumnCount(2);
+    setHorizontalHeaderLabels({ tr("Property"), tr("Value") });
+    horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+    verticalHeader()->setVisible(false);
+}
+
+void TesseractParametersTableWidget::addParameter(const QString &key, const QVariant &value)
+{
+    auto *keyWidget = new QTableWidgetItem(key);
+    auto *valueWidget = new QTableWidgetItem(value.toString());
+    insertRow(rowCount());
+    setItem(rowCount() - 1, 0, keyWidget);
+    setItem(rowCount() - 1, 1, valueWidget);
+}
+
+void TesseractParametersTableWidget::addParameter()
+{
+    addParameter("", "");
+}
+
+void TesseractParametersTableWidget::setParameters(const QMap<QString, QVariant> &parameters)
+{
+    clearContents();
+    setRowCount(0);
+    for (auto it = parameters.cbegin(); it != parameters.cend(); ++it) {
+        addParameter(it.key(), it.value());
+    }
+}
+
+QMap<QString, QVariant> TesseractParametersTableWidget::parameters() const
+{
+    QMap<QString, QVariant> parameters;
+    for (int i = 0; i < rowCount(); ++i) {
+        QString key = item(i, 0)->text();
+        auto value = QVariant(item(i, 1)->text());
+        if (!key.isEmpty() && !value.toString().isEmpty())
+            parameters.insert(key, value);
+    }
+    return parameters;
+}

--- a/src/settings/tesseractparameterstablewidget.cpp
+++ b/src/settings/tesseractparameterstablewidget.cpp
@@ -31,15 +31,17 @@ TesseractParametersTableWidget::TesseractParametersTableWidget(QWidget *parent)
     verticalHeader()->setVisible(false);
 }
 
-void TesseractParametersTableWidget::addParameter(const QString &key, const QVariant &value)
+void TesseractParametersTableWidget::addParameter(const QString &key, const QVariant &value, bool edit)
 {
     auto *keyWidget = new QTableWidgetItem(key);
     auto *valueWidget = new QTableWidgetItem(value.toString());
     insertRow(rowCount());
     setItem(rowCount() - 1, 0, keyWidget);
     setItem(rowCount() - 1, 1, valueWidget);
-    setCurrentItem(keyWidget);
-    editItem(keyWidget);
+    if (edit) {
+        setCurrentItem(keyWidget);
+        editItem(keyWidget);
+    }
 }
 
 void TesseractParametersTableWidget::setParameters(const QMap<QString, QVariant> &parameters)
@@ -47,8 +49,7 @@ void TesseractParametersTableWidget::setParameters(const QMap<QString, QVariant>
     clearContents();
     setRowCount(0);
     for (auto it = parameters.cbegin(); it != parameters.cend(); ++it)
-        addParameter(it.key(), it.value());
-    setCurrentItem(nullptr);
+        addParameter(it.key(), it.value(), false);
 }
 
 QMap<QString, QVariant> TesseractParametersTableWidget::parameters() const
@@ -78,7 +79,7 @@ bool TesseractParametersTableWidget::validateParameters()
             setCurrentItem(key);
             editItem(key);
             return false;
-        } 
+        }
         if (!key->text().isEmpty() && value->text().isEmpty()) {
             setCurrentItem(value);
             editItem(value);

--- a/src/settings/tesseractparameterstablewidget.cpp
+++ b/src/settings/tesseractparameterstablewidget.cpp
@@ -55,14 +55,47 @@ void TesseractParametersTableWidget::setParameters(const QMap<QString, QVariant>
     }
 }
 
-QMap<QString, QVariant> TesseractParametersTableWidget::parameters() const
+QMap<QString, QVariant> TesseractParametersTableWidget::parameters()
 {
+    removeInvalidParameters();
     QMap<QString, QVariant> parameters;
     for (int i = 0; i < rowCount(); ++i) {
         QString key = item(i, 0)->text();
         auto value = QVariant(item(i, 1)->text());
-        if (!key.isEmpty() && !value.toString().isEmpty())
-            parameters.insert(key, value);
+        parameters.insert(key, value);
     }
     return parameters;
+}
+
+// Return false if any key is missing a value or vice versa. Also focus the empty cell.
+bool TesseractParametersTableWidget::validateParameters()
+{
+    for (int i = 0; i < rowCount(); ++i)
+    {
+        QTableWidgetItem *key = item(i, 0);
+        QTableWidgetItem *value = item(i, 1);
+        if (key->text().isEmpty() && !value->text().isEmpty()) {
+            setCurrentItem(key);
+            editItem(key);
+            return false;
+        } 
+        if (!key->text().isEmpty() && value->text().isEmpty()) {
+            setCurrentItem(value);
+            editItem(value);
+            return false;
+        }
+    }
+    return true;
+}
+
+// Remove all rows with empty cells
+void TesseractParametersTableWidget::removeInvalidParameters()
+{
+    for (int i = rowCount() - 1; i >= 0; --i) {
+        QTableWidgetItem *key = item(i, 0);
+        QTableWidgetItem *value = item(i, 1);
+        if (key->text().isEmpty() || value->text().isEmpty()) {
+            removeRow(i);
+        }
+    }
 }

--- a/src/settings/tesseractparameterstablewidget.cpp
+++ b/src/settings/tesseractparameterstablewidget.cpp
@@ -51,14 +51,14 @@ void TesseractParametersTableWidget::setParameters(const QMap<QString, QVariant>
     setCurrentItem(nullptr);
 }
 
-QMap<QString, QVariant> TesseractParametersTableWidget::parameters()
+QMap<QString, QVariant> TesseractParametersTableWidget::parameters() const
 {
-    removeInvalidParameters();
     QMap<QString, QVariant> parameters;
     for (int i = 0; i < rowCount(); ++i) {
         const QString key = item(i, 0)->text();
         const QVariant value = item(i, 1)->text();
-        parameters.insert(key, value);
+        if (!key.isEmpty() && !value.toString().isEmpty())
+            parameters.insert(key, value);
     }
     return parameters;
 }
@@ -86,16 +86,4 @@ bool TesseractParametersTableWidget::validateParameters()
         }
     }
     return true;
-}
-
-// Remove all rows with empty cells
-void TesseractParametersTableWidget::removeInvalidParameters()
-{
-    for (int i = rowCount() - 1; i >= 0; --i) {
-        const QTableWidgetItem *key = item(i, 0);
-        const QTableWidgetItem *value = item(i, 1);
-        if (key->text().isEmpty() || value->text().isEmpty()) {
-            removeRow(i);
-        }
-    }
 }

--- a/src/settings/tesseractparameterstablewidget.h
+++ b/src/settings/tesseractparameterstablewidget.h
@@ -28,8 +28,7 @@ class TesseractParametersTableWidget : public QTableWidget
 public:
     TesseractParametersTableWidget(QWidget *parent = nullptr);
 
-    void addParameter(const QString &key, const QVariant &value);
-    void addParameter();
+    void addParameter(const QString &key = {}, const QVariant &value = {});
     void setParameters(const QMap<QString, QVariant> &parameters);
     QMap<QString, QVariant> parameters();
     bool validateParameters();

--- a/src/settings/tesseractparameterstablewidget.h
+++ b/src/settings/tesseractparameterstablewidget.h
@@ -31,7 +31,7 @@ public:
     TesseractParametersTableWidget(QWidget *parent = nullptr);
 
     void setParameters(const QMap<QString, QVariant> &parameters);
-    QMap<QString, QVariant> parameters();
+    QMap<QString, QVariant> parameters() const;
     bool validateParameters();
     void removeInvalidParameters();
 

--- a/src/settings/tesseractparameterstablewidget.h
+++ b/src/settings/tesseractparameterstablewidget.h
@@ -35,8 +35,8 @@ public:
     bool validateParameters();
     void removeInvalidParameters();
 
-private slots:
-    void addParameter(const QString &key = {}, const QVariant &value = {});
+public slots:
+    void addParameter(const QString &key = {}, const QVariant &value = {}, bool edit = true);
     void removeCurrent();
 };
 

--- a/src/settings/tesseractparameterstablewidget.h
+++ b/src/settings/tesseractparameterstablewidget.h
@@ -25,14 +25,19 @@
 
 class TesseractParametersTableWidget : public QTableWidget
 {
+    Q_OBJECT
+
 public:
     TesseractParametersTableWidget(QWidget *parent = nullptr);
 
-    void addParameter(const QString &key = {}, const QVariant &value = {});
     void setParameters(const QMap<QString, QVariant> &parameters);
     QMap<QString, QVariant> parameters();
     bool validateParameters();
     void removeInvalidParameters();
+
+private slots:
+    void addParameter(const QString &key = {}, const QVariant &value = {});
+    void removeCurrent();
 };
 
 #endif // TESSERACTPARAMETERSTABLEWIDGT_H

--- a/src/settings/tesseractparameterstablewidget.h
+++ b/src/settings/tesseractparameterstablewidget.h
@@ -1,0 +1,37 @@
+/*
+ *  Copyright © 2018-2021 Hennadii Chernyshchyk <genaloner@gmail.com>
+ *
+ *  This file is part of Crow Translate.
+ *
+ *  Crow Translate is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Crow Translate is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a get of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef TESSERACTPARAMETERSTABLEWIDGT_H
+#define TESSERACTPARAMETERSTABLEWIDGT_H
+
+#include <QTableWidget>
+
+class TesseractParametersTableWidget : public QTableWidget
+{
+public:
+    TesseractParametersTableWidget(QWidget *parent = nullptr);
+
+    void addParameter(const QString &key, const QVariant &value);
+    void addParameter();
+    void setParameters(const QMap<QString, QVariant> &parameters);
+    QMap<QString, QVariant> parameters() const;
+};
+
+#endif // TESSERACTPARAMETERSTABLEWIDGT_H

--- a/src/settings/tesseractparameterstablewidget.h
+++ b/src/settings/tesseractparameterstablewidget.h
@@ -31,7 +31,9 @@ public:
     void addParameter(const QString &key, const QVariant &value);
     void addParameter();
     void setParameters(const QMap<QString, QVariant> &parameters);
-    QMap<QString, QVariant> parameters() const;
+    QMap<QString, QVariant> parameters();
+    bool validateParameters();
+    void removeInvalidParameters();
 };
 
 #endif // TESSERACTPARAMETERSTABLEWIDGT_H


### PR DESCRIPTION
This adds the parameter table for tesseract discussed in #233. The first three commits implement the editing, saving, and loading functionality and deal with any invalid rows in the table by silently dropping them before returning the parameters.

The fourth commit adds a validation layer that displays a message and focuses the first invalid cell. It works, but I'm not sure if there's a better way to organize the code for it.