### PR TITLE
Add the ability to change Tesseract parameters via D-Bus

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,13 +9,6 @@ on:
     - '.gitignore'
     - 'crowdin.yml'
     - 'data/translations/**'
-  pull_request:
-    paths-ignore:
-    - '**.md'
-    - '.github/workflows/release.yml'
-    - '.gitignore'
-    - 'crowdin.yml'
-    - 'data/translations/**'
 jobs:
   Main:
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ The program also has a console interface.
 ## D-Bus API
 
     io.crow_translate.CrowTranslate
+    ├── /io/crow_translate/CrowTranslate/Ocr
+    |   └── method void io.crow_translate.CrowTranslate.Ocr.setParameters(QVariantMap parameters);
     └── /io/crow_translate/CrowTranslate/MainWindow
         |   # Global shortcuts
         ├── method void io.crow_translate.CrowTranslate.MainWindow.translateSelection();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -187,7 +187,7 @@ QKeySequence MainWindow::closeWindowShortcut() const
     return m_closeWindowsShortcut->key();
 }
 
-const Ocr *MainWindow::ocr() const
+Ocr *MainWindow::ocr() const
 {
     return m_ocr;
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -879,6 +879,7 @@ void MainWindow::loadAppSettings()
     ui->sourceEdit->setSimplifySource(settings.isSimplifySource());
 
     // OCR settings
+    m_ocr->setParameters(settings.tesseractParameters());
     if (const QByteArray languages = settings.ocrLanguagesString(), path = settings.ocrLanguagesPath(); !m_ocr->setLanguagesString(languages, path)) {
         // Show error only if languages was specified by user
         if (languages != AppSettings::defaultOcrLanguagesString() || path != AppSettings::defaultOcrLanguagesPath())

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -879,8 +879,7 @@ void MainWindow::loadAppSettings()
     ui->sourceEdit->setSimplifySource(settings.isSimplifySource());
 
     // OCR settings
-    m_ocr->setParameters(settings.tesseractParameters());
-    if (const QByteArray languages = settings.ocrLanguagesString(), path = settings.ocrLanguagesPath(); !m_ocr->setLanguagesString(languages, path)) {
+    if (const QByteArray languages = settings.ocrLanguagesString(), path = settings.ocrLanguagesPath(); !m_ocr->init(languages, path, settings.tesseractParameters())) {
         // Show error only if languages was specified by user
         if (languages != AppSettings::defaultOcrLanguagesString() || path != AppSettings::defaultOcrLanguagesPath())
             m_trayIcon->showMessage(Ocr::tr("Unable to set OCR languages"), Ocr::tr("Unable to initialize Tesseract with %1").arg(QString(languages)));

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -63,7 +63,7 @@ public:
     const SpeakButtons *sourceSpeakButtons() const;
     const SpeakButtons *translationSpeakButtons() const;
     QKeySequence closeWindowShortcut() const;
-    const Ocr *ocr() const;
+    Ocr *ocr() const;
 
 public slots:
     // Global shortcuts

--- a/src/ocr/ocr.cpp
+++ b/src/ocr/ocr.cpp
@@ -65,14 +65,6 @@ QByteArray Ocr::languagesString() const
     return QByteArray::fromRawData(m_tesseract.GetInitLanguagesAsString(), qstrlen(m_tesseract.GetInitLanguagesAsString()));
 }
 
-void Ocr::setParameters(const QMap<QString, QVariant> &parameters)
-{
-        for (auto it = parameters.cbegin(); it != parameters.cend(); ++it) {
-            if (!m_tesseract.SetVariable(it.key().toLocal8Bit(), it.value().toByteArray()))
-                qWarning() << tr("%1 is not the name of a valid tesseract parameter.").arg(it.key());
-        }
-}
-
 bool Ocr::setLanguagesString(const QByteArray &languages, const QByteArray &languagesPath)
 {
     // Call even if the specified language is empty to initialize (Tesseract will try to load eng by default)
@@ -134,6 +126,17 @@ QStringList Ocr::availableLanguages(const QString &languagesPath)
     }
 
     return {};
+}
+
+void Ocr::setParameters(const QMap<QString, QVariant> &parameters, bool saveSettings)
+{
+    for (auto it = parameters.cbegin(); it != parameters.cend(); ++it) {
+        if (!m_tesseract.SetVariable(it.key().toLocal8Bit(), it.value().toByteArray()))
+            qWarning() << tr("%1 is not the name of a valid tesseract parameter.").arg(it.key());
+    }
+
+    if (saveSettings)
+        AppSettings().setTesseractParameters(parameters);
 }
 
 QStringList Ocr::parseLanguageFiles(const QDir &directory) 

--- a/src/ocr/ocr.cpp
+++ b/src/ocr/ocr.cpp
@@ -65,12 +65,15 @@ QByteArray Ocr::languagesString() const
     return QByteArray::fromRawData(m_tesseract.GetInitLanguagesAsString(), qstrlen(m_tesseract.GetInitLanguagesAsString()));
 }
 
-bool Ocr::setLanguagesString(const QByteArray &languages, const QByteArray &languagesPath)
+bool Ocr::init(const QByteArray &languages, const QByteArray &languagesPath, const QMap<QString, QVariant> &parameters)
 {
     // Call even if the specified language is empty to initialize (Tesseract will try to load eng by default)
-    if (languagesString() != languages || languages.isEmpty()) {
-        m_defaultParameters.clear(); // All variables will be restored to defaults automatically after new initialization
-        return m_tesseract.Init(languagesPath.isEmpty() ? nullptr : languagesPath.data(), languages.isEmpty() ? nullptr : languages.data(), tesseract::OEM_LSTM_ONLY) == 0;
+    if (languagesString() != languages || languages.isEmpty() || m_parameters != parameters) {
+        m_parameters.clear();
+        m_tesseract.End(); // Should be called to restore all parameters to default
+        if (m_tesseract.Init(languagesPath.isEmpty() ? nullptr : languagesPath.data(), languages.isEmpty() ? nullptr : languages.data(), tesseract::OEM_LSTM_ONLY) != 0)
+            return false;
+        applyParameters(parameters);
     }
 
     // Language are already set
@@ -79,7 +82,7 @@ bool Ocr::setLanguagesString(const QByteArray &languages, const QByteArray &lang
 
 void Ocr::recognize(const QPixmap &pixmap, int dpi) 
 {
-    Q_ASSERT_X(qstrlen(m_tesseract.GetInitLanguagesAsString()) != 0, "recognize", "You should call setLanguagesString first");
+    Q_ASSERT_X(qstrlen(m_tesseract.GetInitLanguagesAsString()) != 0, "recognize", "You should call init first");
 
     m_future.waitForFinished();
     m_future = QtConcurrent::run([this, dpi, image = pixmap.toImage()] {
@@ -130,27 +133,20 @@ QStringList Ocr::availableLanguages(const QString &languagesPath)
     return {};
 }
 
-void Ocr::setParameters(const QMap<QString, QVariant> &parameters, bool saveSettings)
+void Ocr::applyParameters(const QMap<QString, QVariant> &parameters, bool saveSettings)
 {
-    // Restore changed values before to defaults
-    for (auto it = m_defaultParameters.cbegin(); it != m_defaultParameters.cend(); ++it)
-        m_tesseract.SetVariable(it.key(), it.value());
-    m_defaultParameters.clear();
-
     // Apply new parameters
     for (auto it = parameters.cbegin(); it != parameters.cend(); ++it) {
-        const QByteArray key = it.key().toLocal8Bit();
-        const QByteArray value = it.value().toByteArray();
-        const QByteArray defaultValue = m_tesseract.GetStringVariable(key);
-        if (m_tesseract.SetVariable(key, value))
-            m_defaultParameters.insert(key, defaultValue);
+        // Store applied parameters
+        if (m_tesseract.SetVariable(it.key().toLocal8Bit(), it.value().toByteArray()))
+            m_parameters.insert(it.key(), it.value());
         else
             qWarning() << tr("%1 is not the name of a valid tesseract parameter.").arg(it.key());
     }
 
     // Save into settings (used for calling from D-Bus)
     if (saveSettings)
-        AppSettings().setTesseractParameters(parameters);
+        AppSettings().setTesseractParameters(m_parameters);
 }
 
 QStringList Ocr::parseLanguageFiles(const QDir &directory) 

--- a/src/ocr/ocr.h
+++ b/src/ocr/ocr.h
@@ -57,6 +57,7 @@ signals:
 private:
     static QStringList parseLanguageFiles(const QDir &directory);
 
+    QMap<QByteArray, QByteArray> m_defaultParameters;
     QFuture<void> m_future;
     tesseract::TessBaseAPI m_tesseract;
 #if TESSERACT_MAJOR_VERSION < 5

--- a/src/ocr/ocr.h
+++ b/src/ocr/ocr.h
@@ -40,7 +40,7 @@ public:
 
     QStringList availableLanguages() const;
     QByteArray languagesString() const;
-    bool setLanguagesString(const QByteArray &languages, const QByteArray &languagesPath);
+    bool init(const QByteArray &languages, const QByteArray &languagesPath, const QMap<QString, QVariant> &parameters);
 
     void recognize(const QPixmap &pixmap, int dpi);
     void cancel();
@@ -48,7 +48,7 @@ public:
     static QStringList availableLanguages(const QString &languagesPath);
 
 public slots:
-    Q_SCRIPTABLE void setParameters(const QMap<QString, QVariant> &parameters, bool saveSettings = false);
+    Q_SCRIPTABLE void applyParameters(const QMap<QString, QVariant> &parameters, bool saveSettings = false);
 
 signals:
     void recognized(const QString &text);
@@ -57,7 +57,7 @@ signals:
 private:
     static QStringList parseLanguageFiles(const QDir &directory);
 
-    QMap<QByteArray, QByteArray> m_defaultParameters;
+    QMap<QString, QVariant> m_parameters;
     QFuture<void> m_future;
     tesseract::TessBaseAPI m_tesseract;
 #if TESSERACT_MAJOR_VERSION < 5

--- a/src/ocr/ocr.h
+++ b/src/ocr/ocr.h
@@ -38,6 +38,7 @@ public:
 
     QStringList availableLanguages() const;
     QByteArray languagesString() const;
+    void setParameters(const QMap<QString, QVariant> &parameters);
     bool setLanguagesString(const QByteArray &languages, const QByteArray &languagesPath);
 
     void recognize(const QPixmap &pixmap, int dpi);

--- a/src/ocr/ocr.h
+++ b/src/ocr/ocr.h
@@ -32,19 +32,23 @@ class QDir;
 class Ocr : public QObject
 {
     Q_OBJECT
+    Q_CLASSINFO("D-Bus Interface", "io.crow_translate.CrowTranslate.Ocr")
+    Q_DISABLE_COPY(Ocr)
 
 public:
     explicit Ocr(QObject *parent = nullptr);
 
     QStringList availableLanguages() const;
     QByteArray languagesString() const;
-    void setParameters(const QMap<QString, QVariant> &parameters);
     bool setLanguagesString(const QByteArray &languages, const QByteArray &languagesPath);
 
     void recognize(const QPixmap &pixmap, int dpi);
     void cancel();
 
     static QStringList availableLanguages(const QString &languagesPath);
+
+public slots:
+    Q_SCRIPTABLE void setParameters(const QMap<QString, QVariant> &parameters, bool saveSettings = false);
 
 signals:
     void recognized(const QString &text);


### PR DESCRIPTION
@LiteracyFanatic, could you check if it works for you? But you need an application that supports QVariantMap. For example, `dbus-send` and `qdbus` do not support this, but `gdbus` can:

```bash
gdbus call --session -d io.crow_translate.CrowTranslate -o /io/crow_translate/CrowTranslate/Ocr -m io.crow_translate.CrowTranslate.Ocr.setParameters "{'name': <'value'>}"
```