### PR TITLE
Fix XFWM behaviour

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -216,6 +216,12 @@ void MainWindow::open()
 
     setWindowState(windowState() & ~Qt::WindowMinimized);
     show();
+
+    // Required to show the application on some WMs like XFWM
+    // if window already opened on different workspace. Doesn't
+    // affect KWin.
+    raise();
+
     activateWindow();
 }
 


### PR DESCRIPTION
This pull request fix XFWM behaviour. Now clicking by tray icon open Crow window on any workplace, even if it was opened on another workplace. Hopefully fixes #342.