### PR TITLE
Add shortcut to save and close AddLanguageDialog

### DIFF
--- a/src/addlanguagedialog.cpp
+++ b/src/addlanguagedialog.cpp
@@ -30,12 +30,12 @@ AddLanguageDialog::AddLanguageDialog(const QVector<QOnlineTranslator::Language> 
     : QDialog(parent)
     , ui(new Ui::AddLanguageDialog)
     , m_searchShortcut(new QShortcut(QStringLiteral("Ctrl+F"), this))
-    , m_saveAndCloseShortcut(new QShortcut(QStringLiteral("Ctrl+Enter"), this))
+    , m_acceptShortcut(new QShortcut(QStringLiteral("Ctrl+Enter"), this))
 {
     ui->setupUi(this);
     ui->searchEdit->setPlaceholderText(tr("Filter (%1)").arg(m_searchShortcut->key().toString()));
     connect(m_searchShortcut, &QShortcut::activated, ui->searchEdit, qOverload<>(&QLineEdit::setFocus));
-    connect(m_saveAndCloseShortcut, &QShortcut::activated, this, &AddLanguageDialog::accept);
+    connect(m_acceptShortcut, &QShortcut::activated, this, &AddLanguageDialog::accept);
 
     // Load languages
     for (int i = 1; i <= QOnlineTranslator::Zulu; ++i) {

--- a/src/addlanguagedialog.h
+++ b/src/addlanguagedialog.h
@@ -65,7 +65,7 @@ private:
 
     Ui::AddLanguageDialog *ui;
     QShortcut *m_searchShortcut;
-    QShortcut *m_saveAndCloseShortcut;
+    QShortcut *m_acceptShortcut;
     QVector<QOnlineTranslator::Language> m_languages;
 };
 


### PR DESCRIPTION
This PR is compliment to my previous contribution (#361), adding shortcut - `Ctrl+Enter` to save and close AddLanguagesDialog.