### PR TITLE
#include <sys/select.h> to waylandplasmascreengrabber.cpp

### DIFF
--- a/src/ocr/screengrabbers/waylandplasmascreengrabber.cpp
+++ b/src/ocr/screengrabbers/waylandplasmascreengrabber.cpp
@@ -28,6 +28,7 @@
 #include <QtConcurrent>
 
 #include <fcntl.h>
+#include <sys/select.h>
 #include <unistd.h>
 
 using ScreenImagesMap = QMap<const QScreen *, QImage>;


### PR DESCRIPTION
When building on void/x86_64/linux-musl/wayland, I got this:
`
/working/dictionary_and_thesaurus/crow-translate/src/ocr/screengrabbers/waylandplasmascreengrabber.cpp:92:5: error: unknown type name 'fd_set'
    fd_set readset;
`
`
/working/dictionary_and_thesaurus/crow-translate/src/ocr/screengrabbers/waylandplasmascreengrabber.cpp:95:5: error: unknown type name 'timeval'
    timeval timeout{30, 0};
`
`
/working/dictionary_and_thesaurus/crow-translate/src/ocr/screengrabbers/waylandplasmascreengrabber.cpp:102:34: error: use of undeclared identifier 'FD_SETSIZE'
        const int ready = select(FD_SETSIZE, &readset, nullptr, nullptr, &timeout);
`
In waylandplasmascreengrabber.cpp, I added
`
#include <sys/select.h>
`
Build  succeeded.