### PR TITLE
Retrieve parent window ID for XDG desktop portal dialogs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,7 @@ add_executable(${PROJECT_NAME}
 
 if(UNIX)
     target_sources(${PROJECT_NAME} PRIVATE
+        src/xdgdesktopportal.cpp
         src/ocr/screengrabbers/dbusscreengrabber.cpp
         src/ocr/screengrabbers/waylandgnomescreengrabber.cpp
         src/ocr/screengrabbers/waylandplasmascreengrabber.cpp

--- a/src/ocr/screengrabbers/waylandportalscreengrabber.cpp
+++ b/src/ocr/screengrabbers/waylandportalscreengrabber.cpp
@@ -20,6 +20,8 @@
 
 #include "waylandportalscreengrabber.h"
 
+#include "xdgdesktopportal.h"
+
 #include <QDBusInterface>
 #include <QDBusPendingCallWatcher>
 #include <QDBusReply>
@@ -49,9 +51,7 @@ bool WaylandPortalScreenGrabber::isAvailable()
 
 void WaylandPortalScreenGrabber::grab()
 {
-    // TODO: Retrieve parent window in string form
-    // as a second argument according to https://flatpak.github.io/xdg-desktop-portal/#parent_window
-    const QDBusPendingReply<QDBusObjectPath> reply = s_interface.asyncCall(QStringLiteral("Screenshot"), QString(), QVariantMap());
+    const QDBusPendingReply<QDBusObjectPath> reply = s_interface.asyncCall(QStringLiteral("Screenshot"), XdgDesktopPortal::parentWindow(), QVariantMap());
     m_callWatcher = new QDBusPendingCallWatcher(reply, this);
     connect(m_callWatcher, &QDBusPendingCallWatcher::finished, [this] {
         const QDBusPendingReply<QDBusObjectPath> reply = readReply<QDBusObjectPath>();

--- a/src/ocr/screengrabbers/waylandportalscreengrabber.cpp
+++ b/src/ocr/screengrabbers/waylandportalscreengrabber.cpp
@@ -52,7 +52,7 @@ bool WaylandPortalScreenGrabber::isAvailable()
 
 void WaylandPortalScreenGrabber::grab()
 {
-    const WId window = qobject_cast<QWidget *>(parent())->winId();
+    auto *window = qobject_cast<QWidget *>(parent())->windowHandle();
     const QDBusPendingReply<QDBusObjectPath> reply = s_interface.asyncCall(QStringLiteral("Screenshot"), XdgDesktopPortal::parentWindow(window), QVariantMap());
     m_callWatcher = new QDBusPendingCallWatcher(reply, this);
     connect(m_callWatcher, &QDBusPendingCallWatcher::finished, [this] {

--- a/src/ocr/screengrabbers/waylandportalscreengrabber.cpp
+++ b/src/ocr/screengrabbers/waylandportalscreengrabber.cpp
@@ -52,7 +52,7 @@ bool WaylandPortalScreenGrabber::isAvailable()
 
 void WaylandPortalScreenGrabber::grab()
 {
-    auto *window = qobject_cast<QWidget *>(parent())->windowHandle();
+    WId window = qobject_cast<QWidget *>(parent())->winId();
     const QDBusPendingReply<QDBusObjectPath> reply = s_interface.asyncCall(QStringLiteral("Screenshot"), XdgDesktopPortal::parentWindow(window), QVariantMap());
     m_callWatcher = new QDBusPendingCallWatcher(reply, this);
     connect(m_callWatcher, &QDBusPendingCallWatcher::finished, [this] {

--- a/src/ocr/screengrabbers/waylandportalscreengrabber.cpp
+++ b/src/ocr/screengrabbers/waylandportalscreengrabber.cpp
@@ -28,6 +28,7 @@
 #include <QFile>
 #include <QPixmap>
 #include <QUrl>
+#include <QWidget>
 
 // https://github.com/flatpak/xdg-desktop-portal/blob/89d2197002f164d02d891c530dcaa2808f27f593/data/org.freedesktop.portal.Screenshot.xml
 QDBusInterface WaylandPortalScreenGrabber::s_interface(QStringLiteral("org.freedesktop.portal.Desktop"),
@@ -51,7 +52,8 @@ bool WaylandPortalScreenGrabber::isAvailable()
 
 void WaylandPortalScreenGrabber::grab()
 {
-    const QDBusPendingReply<QDBusObjectPath> reply = s_interface.asyncCall(QStringLiteral("Screenshot"), XdgDesktopPortal::parentWindow(), QVariantMap());
+    auto *window = qobject_cast<QWidget *>(parent())->windowHandle();
+    const QDBusPendingReply<QDBusObjectPath> reply = s_interface.asyncCall(QStringLiteral("Screenshot"), XdgDesktopPortal::parentWindow(window), QVariantMap());
     m_callWatcher = new QDBusPendingCallWatcher(reply, this);
     connect(m_callWatcher, &QDBusPendingCallWatcher::finished, [this] {
         const QDBusPendingReply<QDBusObjectPath> reply = readReply<QDBusObjectPath>();

--- a/src/ocr/screengrabbers/waylandportalscreengrabber.cpp
+++ b/src/ocr/screengrabbers/waylandportalscreengrabber.cpp
@@ -52,7 +52,7 @@ bool WaylandPortalScreenGrabber::isAvailable()
 
 void WaylandPortalScreenGrabber::grab()
 {
-    WId window = qobject_cast<QWidget *>(parent())->winId();
+    const WId window = qobject_cast<QWidget *>(parent())->winId();
     const QDBusPendingReply<QDBusObjectPath> reply = s_interface.asyncCall(QStringLiteral("Screenshot"), XdgDesktopPortal::parentWindow(window), QVariantMap());
     m_callWatcher = new QDBusPendingCallWatcher(reply, this);
     connect(m_callWatcher, &QDBusPendingCallWatcher::finished, [this] {

--- a/src/settings/autostartmanager/portalautostartmanager.cpp
+++ b/src/settings/autostartmanager/portalautostartmanager.cpp
@@ -43,7 +43,7 @@ bool PortalAutostartManager::isAutostartEnabled() const
 
 void PortalAutostartManager::setAutostartEnabled(bool enabled)
 {
-    WId window = qobject_cast<QWidget *>(parent())->winId();
+    const WId window = qobject_cast<QWidget *>(parent())->winId();
     const QVariantMap options{
         {QStringLiteral("reason"), QStringLiteral("Allow Crow Translate to manage autostart setting for itself.")},
         {QStringLiteral("autostart"), enabled},

--- a/src/settings/autostartmanager/portalautostartmanager.cpp
+++ b/src/settings/autostartmanager/portalautostartmanager.cpp
@@ -24,6 +24,7 @@
 #include "settings/appsettings.h"
 
 #include <QDBusReply>
+#include <QWidget>
 #include <QtCore>
 
 QDBusInterface PortalAutostartManager::s_interface(QStringLiteral("org.freedesktop.portal.Desktop"),
@@ -42,13 +43,14 @@ bool PortalAutostartManager::isAutostartEnabled() const
 
 void PortalAutostartManager::setAutostartEnabled(bool enabled)
 {
+    auto *window = qobject_cast<QWidget *>(parent())->windowHandle();
     const QVariantMap options{
         {QStringLiteral("reason"), QStringLiteral("Allow Crow Translate to manage autostart setting for itself.")},
         {QStringLiteral("autostart"), enabled},
         {QStringLiteral("commandline"), QStringList{QCoreApplication::applicationFilePath()}},
         {QStringLiteral("dbus-activatable"), false},
     };
-    const QDBusReply<QDBusObjectPath> reply = s_interface.call(QStringLiteral("RequestBackground"), XdgDesktopPortal::parentWindow(), options);
+    const QDBusReply<QDBusObjectPath> reply = s_interface.call(QStringLiteral("RequestBackground"), XdgDesktopPortal::parentWindow(window), options);
 
     if (!reply.isValid()) {
         showError(reply.error().message());

--- a/src/settings/autostartmanager/portalautostartmanager.cpp
+++ b/src/settings/autostartmanager/portalautostartmanager.cpp
@@ -43,7 +43,7 @@ bool PortalAutostartManager::isAutostartEnabled() const
 
 void PortalAutostartManager::setAutostartEnabled(bool enabled)
 {
-    const WId window = qobject_cast<QWidget *>(parent())->winId();
+    auto *window = qobject_cast<QWidget *>(parent())->windowHandle();
     const QVariantMap options{
         {QStringLiteral("reason"), QStringLiteral("Allow Crow Translate to manage autostart setting for itself.")},
         {QStringLiteral("autostart"), enabled},

--- a/src/settings/autostartmanager/portalautostartmanager.cpp
+++ b/src/settings/autostartmanager/portalautostartmanager.cpp
@@ -43,7 +43,7 @@ bool PortalAutostartManager::isAutostartEnabled() const
 
 void PortalAutostartManager::setAutostartEnabled(bool enabled)
 {
-    auto *window = qobject_cast<QWidget *>(parent())->windowHandle();
+    WId window = qobject_cast<QWidget *>(parent())->winId();
     const QVariantMap options{
         {QStringLiteral("reason"), QStringLiteral("Allow Crow Translate to manage autostart setting for itself.")},
         {QStringLiteral("autostart"), enabled},

--- a/src/settings/autostartmanager/portalautostartmanager.cpp
+++ b/src/settings/autostartmanager/portalautostartmanager.cpp
@@ -20,6 +20,7 @@
 
 #include "portalautostartmanager.h"
 
+#include "xdgdesktopportal.h"
 #include "settings/appsettings.h"
 
 #include <QDBusReply>
@@ -47,9 +48,7 @@ void PortalAutostartManager::setAutostartEnabled(bool enabled)
         {QStringLiteral("commandline"), QStringList{QCoreApplication::applicationFilePath()}},
         {QStringLiteral("dbus-activatable"), false},
     };
-    // TODO: Retrieve parent window in string form
-    // as a second argument according to https://flatpak.github.io/xdg-desktop-portal/#parent_window
-    const QDBusReply<QDBusObjectPath> reply = s_interface.call(QStringLiteral("RequestBackground"), QString(), options);
+    const QDBusReply<QDBusObjectPath> reply = s_interface.call(QStringLiteral("RequestBackground"), XdgDesktopPortal::parentWindow(), options);
 
     if (!reply.isValid()) {
         showError(reply.error().message());

--- a/src/xdgdesktopportal.cpp
+++ b/src/xdgdesktopportal.cpp
@@ -22,9 +22,10 @@
 #include "xdgdesktopportal.h"
 
 #include <QDebug>
+#include <QWindow>
 #include <QX11Info>
 
-QString XdgDesktopPortal::parentWindow(WId activeWindow)
+QString XdgDesktopPortal::parentWindow(const QWindow *activeWindow)
 {
     if (!QX11Info::isPlatformX11()) {
         // TODO Implement Wayland window ID using https://wayland.app/protocols/xdg-foreign-unstable-v2
@@ -32,5 +33,5 @@ QString XdgDesktopPortal::parentWindow(WId activeWindow)
         return {};
     }
 
-    return QStringLiteral("x11:%1").arg(activeWindow, 0, 16);
+    return QStringLiteral("x11:%1").arg(activeWindow->winId(), 0, 16);
 }

--- a/src/xdgdesktopportal.cpp
+++ b/src/xdgdesktopportal.cpp
@@ -21,10 +21,21 @@
 
 #include "xdgdesktopportal.h"
 
+#include <QDebug>
 #include <QX11Info>
 
 QString XdgDesktopPortal::parentWindow(QWindow *activeWindow)
 {
-    const QString platformName = QX11Info::isPlatformX11() ? QStringLiteral("x11") : QStringLiteral("wayland");
-    return QStringLiteral("%1:%2").arg(platformName).arg(activeWindow->winId());
+    QString platformName;
+    QString windowID;
+    if (QX11Info::isPlatformX11()) {
+        platformName = QStringLiteral("x11");
+        windowID = QStringLiteral("%1").arg(activeWindow->winId(), 0, 16);
+    } else {
+        platformName = QStringLiteral("wayland");
+        // TODO Implement Wayland window ID using https://wayland.app/protocols/xdg-foreign-unstable-v2
+        qWarning() << "Retrieving XDP window ID on Wayland not implemented";
+        return "";
+    }
+    return QStringLiteral("%1:%2").arg(platformName).arg(windowID);
 }

--- a/src/xdgdesktopportal.cpp
+++ b/src/xdgdesktopportal.cpp
@@ -24,18 +24,13 @@
 #include <QDebug>
 #include <QX11Info>
 
-QString XdgDesktopPortal::parentWindow(QWindow *activeWindow)
+QString XdgDesktopPortal::parentWindow(WId activeWindow)
 {
-    QString platformName;
-    QString windowID;
-    if (QX11Info::isPlatformX11()) {
-        platformName = QStringLiteral("x11");
-        windowID = QStringLiteral("%1").arg(activeWindow->winId(), 0, 16);
-    } else {
-        platformName = QStringLiteral("wayland");
+    if (!QX11Info::isPlatformX11()) {
         // TODO Implement Wayland window ID using https://wayland.app/protocols/xdg-foreign-unstable-v2
         qWarning() << "Retrieving XDP window ID on Wayland not implemented";
-        return "";
+        return {};
     }
-    return QStringLiteral("%1:%2").arg(platformName).arg(windowID);
+
+    return QStringLiteral("x11:%1").arg(activeWindow, 0, 16);
 }

--- a/src/xdgdesktopportal.cpp
+++ b/src/xdgdesktopportal.cpp
@@ -1,0 +1,37 @@
+
+/*
+ *  Copyright © 2018-2022 Hennadii Chernyshchyk <genaloner@gmail.com>
+ *
+ *  This file is part of Crow Translate.
+ *
+ *  Crow Translate is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Crow Translate is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a get of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "xdgdesktopportal.h"
+
+#include <QApplication>
+#include <QWidget>
+#include <QX11Info>
+
+QString XdgDesktopPortal::parentWindow()
+{
+    const QWidget *activeWindow = QApplication::activeWindow();
+    if (activeWindow == nullptr)
+        return {};
+
+    const QString platformName = QX11Info::isPlatformX11() ? QStringLiteral("x11") : QStringLiteral("wayland");
+    return QStringLiteral("%1:%2").arg(platformName).arg(activeWindow->winId());
+
+}

--- a/src/xdgdesktopportal.cpp
+++ b/src/xdgdesktopportal.cpp
@@ -21,17 +21,10 @@
 
 #include "xdgdesktopportal.h"
 
-#include <QApplication>
-#include <QWidget>
 #include <QX11Info>
 
-QString XdgDesktopPortal::parentWindow()
+QString XdgDesktopPortal::parentWindow(QWindow *activeWindow)
 {
-    const QWidget *activeWindow = QApplication::activeWindow();
-    if (activeWindow == nullptr)
-        return {};
-
     const QString platformName = QX11Info::isPlatformX11() ? QStringLiteral("x11") : QStringLiteral("wayland");
     return QStringLiteral("%1:%2").arg(platformName).arg(activeWindow->winId());
-
 }

--- a/src/xdgdesktopportal.h
+++ b/src/xdgdesktopportal.h
@@ -23,12 +23,13 @@
 #define XDGDESKTOPPORTAL_H
 
 #include <QString>
+#include <QWindow>
 
 namespace XdgDesktopPortal
 {
 // Retrieve parent window in string form according to
 // https://flatpak.github.io/xdg-desktop-portal/#parent_window
-QString parentWindow();
+QString parentWindow(QWindow *activeWindow);
 }
 
 #endif // XDGDESKTOPPORTAL_H

--- a/src/xdgdesktopportal.h
+++ b/src/xdgdesktopportal.h
@@ -1,0 +1,34 @@
+
+/*
+ *  Copyright © 2018-2022 Hennadii Chernyshchyk <genaloner@gmail.com>
+ *
+ *  This file is part of Crow Translate.
+ *
+ *  Crow Translate is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Crow Translate is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a get of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef XDGDESKTOPPORTAL_H
+#define XDGDESKTOPPORTAL_H
+
+#include <QString>
+
+namespace XdgDesktopPortal
+{
+// Retrieve parent window in string form according to
+// https://flatpak.github.io/xdg-desktop-portal/#parent_window
+QString parentWindow();
+}
+
+#endif // XDGDESKTOPPORTAL_H

--- a/src/xdgdesktopportal.h
+++ b/src/xdgdesktopportal.h
@@ -23,13 +23,14 @@
 #define XDGDESKTOPPORTAL_H
 
 #include <QString>
-#include <QWidget>
+
+class QWindow;
 
 namespace XdgDesktopPortal
 {
 // Retrieve parent window in string form according to
 // https://flatpak.github.io/xdg-desktop-portal/#parent_window
-QString parentWindow(WId activeWindow);
+QString parentWindow(const QWindow *activeWindow);
 }
 
 #endif // XDGDESKTOPPORTAL_H

--- a/src/xdgdesktopportal.h
+++ b/src/xdgdesktopportal.h
@@ -23,13 +23,13 @@
 #define XDGDESKTOPPORTAL_H
 
 #include <QString>
-#include <QWindow>
+#include <QWidget>
 
 namespace XdgDesktopPortal
 {
 // Retrieve parent window in string form according to
 // https://flatpak.github.io/xdg-desktop-portal/#parent_window
-QString parentWindow(QWindow *activeWindow);
+QString parentWindow(WId activeWindow);
 }
 
 #endif // XDGDESKTOPPORTAL_H


### PR DESCRIPTION
Follow-up from https://github.com/crow-translate/crow-translate/pull/429#issuecomment-1126707432, attempt to fix #430

It doesn't crash anymore even if we don't check if the active window isn't `nullptr`, but I'm still not sure if this way to determine `parent_window` ID for XDP is correct. Looks like it is for X11, but not for Wayland.