### PR TITLE
Portuguese European pt-PT translatio complete

### DIFF
--- a/data/translations/crow-translate_pt_PT.ts
+++ b/data/translations/crow-translate_pt_PT.ts
@@ -1,0 +1,2490 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt-PT" sourcelanguage="en">
+  <context>
+    <name>AbstractAutostartManager</name>
+    <message>
+      <location filename="../../src/settings/autostartmanager/abstractautostartmanager.cpp" line="53"/>
+      <source>Unable to apply autostart settings</source>
+      <translation>Não foi possível aplicar as configurações de início automático</translation>
+    </message>
+  </context>
+  <context>
+    <name>AbstractScreenGrabber</name>
+    <message>
+      <location filename="../../src/ocr/screengrabbers/abstractscreengrabber.cpp" line="64"/>
+      <source>Unable to grab screen</source>
+      <translation>Não é possível capturar o ecrã</translation>
+    </message>
+  </context>
+  <context>
+    <name>AddLanguageDialog</name>
+    <message>
+      <location filename="../../src/addlanguagedialog.ui" line="14"/>
+      <source>Add language</source>
+      <translation>Adicionar idioma</translation>
+    </message>
+    <message>
+      <location filename="../../src/addlanguagedialog.ui" line="91"/>
+      <source>Available languages:</source>
+      <translation>Idiomas disponíveis:</translation>
+    </message>
+    <message>
+      <location filename="../../src/addlanguagedialog.ui" line="104"/>
+      <source>Current languages:</source>
+      <translation>Idiomas atuais:</translation>
+    </message>
+    <message>
+      <location filename="../../src/addlanguagedialog.cpp" line="36"/>
+      <source>Filter (%1)</source>
+      <translation>Filtro (%1)</translation>
+    </message>
+  </context>
+  <context>
+    <name>AppSettings</name>
+    <message>
+      <location filename="../../src/settings/appsettings.cpp" line="1196"/>
+      <source>Unknown language code: %1</source>
+      <translation>Código de idioma desconhecido: %1</translation>
+    </message>
+  </context>
+  <context>
+    <name>Cli</name>
+    <message>
+      <location filename="../../src/cli.cpp" line="53"/>
+      <source>Display all language codes.</source>
+      <translation>Mostra todos os códigos de idioma.</translation>
+    </message>
+    <message>
+      <location filename="../../src/cli.cpp" line="54"/>
+      <source>Specify the source language (by default, engine will try to determine the language on its own).</source>
+      <translation>Especifica o idioma de origem (por padrão, o mecanismo tentará determinar o idioma por si próprio).</translation>
+    </message>
+    <message>
+      <location filename="../../src/cli.cpp" line="55"/>
+      <source>Specify the translation language(s), splitted by &apos;+&apos; (by default, the system language is used).</source>
+      <translation>Especifica o(s) idioma(s) de tradução, separados por &apos;+&apos; (por padrão, o idioma do sistema é usado).</translation>
+    </message>
+    <message>
+      <location filename="../../src/cli.cpp" line="56"/>
+      <source>Specify the translator language (by default, the system language is used).</source>
+      <translation>Especifica o idioma de tradução (por padrão, o idioma do sistema é usado).</translation>
+    </message>
+    <message>
+      <location filename="../../src/cli.cpp" line="58"/>
+      <source>Speak the translation.</source>
+      <translation>Fala a tradução.</translation>
+    </message>
+    <message>
+      <location filename="../../src/cli.cpp" line="59"/>
+      <source>Speak the source.</source>
+      <translation>Fala o texto original.</translation>
+    </message>
+    <message>
+      <location filename="../../src/cli.cpp" line="60"/>
+      <source>Read source text from files. Arguments will be interpreted as file paths.</source>
+      <translation>Lê o texto original em arquivos. Argumentos serão interpretados como caminhos de arquivo.</translation>
+    </message>
+    <message>
+      <location filename="../../src/cli.cpp" line="61"/>
+      <source>Add stdin data to source text.</source>
+      <translation>Adiciona dados do stdin para o texto de origem.</translation>
+    </message>
+    <message>
+      <location filename="../../src/cli.cpp" line="62"/>
+      <source>Do not print any text when using --%1 or --%2.</source>
+      <translation>Não imprimir nenhum texto quando estiver usando --%1 ou --%2.</translation>
+    </message>
+    <message>
+      <location filename="../../src/cli.cpp" line="64"/>
+      <source>Print output formatted as JSON.</source>
+      <translation>Imprimir saída formatada como JSON.</translation>
+    </message>
+    <message>
+      <location filename="../../src/cli.cpp" line="68"/>
+      <source>Text to translate. By default, the translation will be done to the system language.</source>
+      <translation>Texto para traduzir. Por padrão, a tradução será feita no idioma do sistema.</translation>
+    </message>
+    <message>
+      <location filename="../../src/cli.cpp" line="366"/>
+      <source>Error: You can&apos;t use --%1 with --%2</source>
+      <translation>Erro: Você não pode usar --%1 com --%2</translation>
+    </message>
+    <message>
+      <location filename="../../src/cli.cpp" line="140"/>
+      <source>Error: Unknown engine</source>
+      <translation>Erro: Mecanismo desconhecido</translation>
+    </message>
+    <message>
+      <location filename="../../src/cli.cpp" line="124"/>
+      <source>Error: There is no text for translation</source>
+      <translation>Erro: Não há texto para tradução</translation>
+    </message>
+    <message>
+      <location filename="../../src/cli.cpp" line="63"/>
+      <source>Print only translations.</source>
+      <translation>Imprimir apenas traduções.</translation>
+    </message>
+    <message>
+      <location filename="../../src/cli.cpp" line="57"/>
+      <source>Specify the translator engine (&apos;google&apos;, &apos;yandex&apos;, &apos;bing&apos;, &apos;libretranslate&apos; or &apos;lingva&apos;), Google is used by default.</source>
+      <translation>Especificar o mecanismo de tradução (&apos;google&apos;, &apos;yandex&apos;, &apos;bing&apos;, &apos;libretranslate&apos; ou &apos;lingva&apos;), Google é usado por padrão.</translation>
+    </message>
+    <message>
+      <location filename="../../src/cli.cpp" line="67"/>
+      <source>A simple and lightweight translator that allows to translate and speak text using Google, Yandex, Bing, LibreTranslate and Lingva</source>
+      <translation>Um tradutor simples e leve que permite traduzir e reproduzir texto usando o Google, Yandex, Bing, LibreTranslate e Lingva</translation>
+    </message>
+    <message>
+      <location filename="../../src/cli.cpp" line="175"/>
+      <location filename="../../src/cli.cpp" line="264"/>
+      <location filename="../../src/cli.cpp" line="353"/>
+      <source>Error: %1</source>
+      <translation>Erro: %1</translation>
+    </message>
+    <message>
+      <location filename="../../src/cli.cpp" line="382"/>
+      <location filename="../../src/cli.cpp" line="403"/>
+      <source>Error: File does not exist: %1</source>
+      <translation>Erro: Arquivo não existe: %1</translation>
+    </message>
+    <message>
+      <location filename="../../src/cli.cpp" line="387"/>
+      <location filename="../../src/cli.cpp" line="408"/>
+      <source>Error: Unable to open file: %1</source>
+      <translation>Erro: Não foi possível abrir o arquivo: %1</translation>
+    </message>
+    <message>
+      <location filename="../../src/cli.cpp" line="225"/>
+      <source>%1 - translation options:</source>
+      <translation>%1 - opções de tradução:</translation>
+    </message>
+    <message>
+      <location filename="../../src/cli.cpp" line="90"/>
+      <source>Error: For --%1 you must specify --%2 and/or --%3 options</source>
+      <translation>Erro: Para --%1, você deve especificar as opções --%2 e/ou --%3</translation>
+    </message>
+    <message>
+      <location filename="../../src/cli.cpp" line="242"/>
+      <source>%1 - examples:</source>
+      <translation>%1 - exemplos:</translation>
+    </message>
+  </context>
+  <context>
+    <name>ContextMenu</name>
+    <message>
+      <location filename="../../src/contextmenu.h" line="52"/>
+      <source>Search on Forvo.com</source>
+      <translation>Pesquisar em Forvo.com</translation>
+    </message>
+  </context>
+  <context>
+    <name>D-Bus</name>
+    <message>
+      <location filename="../../src/main.cpp" line="101"/>
+      <source>Unable to register D-Bus object for %1</source>
+      <translation>Não foi possível registrar objeto D-Bus para %1</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="77"/>
+      <source>D-Bus service %1 is already registered by another application</source>
+      <translation>O serviço D-Bus %1 já está registrado por outro aplicativo</translation>
+    </message>
+  </context>
+  <context>
+    <name>LanguageButtonsWidget</name>
+    <message>
+      <location filename="../../src/languagebuttonswidget.cpp" line="461"/>
+      <source>Window width is larger than screen due to the languages on the panel.</source>
+      <translation>A largura da janela é maior que a tela devido aos idiomas no painel.</translation>
+    </message>
+    <message>
+      <location filename="../../src/languagebuttonswidget.cpp" line="462"/>
+      <source>Please reduce added languages.</source>
+      <translation>Por favor, reduza os idiomas adicionados.</translation>
+    </message>
+    <message>
+      <location filename="../../src/languagebuttonswidget.cpp" line="538"/>
+      <location filename="../../src/languagebuttonswidget.cpp" line="540"/>
+      <source>Auto</source>
+      <translation>Automático</translation>
+    </message>
+  </context>
+  <context>
+    <name>MainWindow</name>
+    <message>
+      <location filename="../../src/mainwindow.ui" line="36"/>
+      <source>Copy source text to the clipboard</source>
+      <translation>Copiar texto original para a área de transferência</translation>
+    </message>
+    <message>
+      <location filename="../../src/mainwindow.ui" line="114"/>
+      <source>Source</source>
+      <translation>Origem</translation>
+    </message>
+    <message>
+      <location filename="../../src/mainwindow.ui" line="250"/>
+      <source>Copy translation to the clipboard</source>
+      <translation>Copiar tradução para a área de transferência</translation>
+    </message>
+    <message>
+      <location filename="../../src/mainwindow.ui" line="261"/>
+      <source>Copy all translation data to the clipboard</source>
+      <translation>Copiar todos os dados da tradução para a área de transferência</translation>
+    </message>
+    <message>
+      <location filename="../../src/mainwindow.ui" line="272"/>
+      <source>Translate screen area with delay</source>
+      <translation>Traduzir a área da tela com atraso</translation>
+    </message>
+    <message>
+      <location filename="../../src/mainwindow.ui" line="283"/>
+      <source>Application settings</source>
+      <translation>Configurações da aplicação</translation>
+    </message>
+    <message>
+      <location filename="../../src/mainwindow.ui" line="93"/>
+      <source>Swap languages</source>
+      <translation>Alternar idiomas</translation>
+    </message>
+    <message>
+      <location filename="../../src/mainwindow.ui" line="47"/>
+      <source>Recognize screen area with delay</source>
+      <translation>Reconhecer área da tela com atraso</translation>
+    </message>
+    <message>
+      <location filename="../../src/mainwindow.ui" line="70"/>
+      <source>Auto-translation</source>
+      <extracomment>The text should be short to fit in portrait orientation on phones.</extracomment>
+      <translation>Tradução automática</translation>
+    </message>
+    <message>
+      <location filename="../../src/mainwindow.ui" line="82"/>
+      <source>Cancel</source>
+      <translation>Cancelar</translation>
+    </message>
+    <message>
+      <location filename="../../src/mainwindow.ui" line="121"/>
+      <source>Clear</source>
+      <translation>Limpar</translation>
+    </message>
+    <message>
+      <location filename="../../src/mainwindow.ui" line="138"/>
+      <source>Translate</source>
+      <translation>Traduzir</translation>
+    </message>
+    <message>
+      <location filename="../../src/mainwindow.ui" line="166"/>
+      <source>Translation</source>
+      <translation>Tradução</translation>
+    </message>
+    <message>
+      <location filename="../../src/mainwindow.cpp" line="406"/>
+      <source>Unable to detect language</source>
+      <translation>Não foi possível detectar o idioma</translation>
+    </message>
+    <message>
+      <location filename="../../src/mainwindow.cpp" line="458"/>
+      <source>Unable to translate text</source>
+      <translation>Não foi possível traduzir o texto</translation>
+    </message>
+  </context>
+  <context>
+    <name>Ocr</name>
+    <message>
+      <location filename="../../src/mainwindow.cpp" line="976"/>
+      <source>Unable to set OCR languages</source>
+      <translation>Não foi possível definir idiomas OCR</translation>
+    </message>
+    <message>
+      <location filename="../../src/mainwindow.cpp" line="976"/>
+      <source>Unable to initialize Tesseract with %1</source>
+      <translation>Não foi possível inicializar Tesseract com %1</translation>
+    </message>
+    <message>
+      <location filename="../../src/transitions/ocruninitializedtransition.cpp" line="41"/>
+      <source>OCR languages are not loaded</source>
+      <translation>Idiomas OCR não estão carregados</translation>
+    </message>
+    <message>
+      <location filename="../../src/transitions/ocruninitializedtransition.cpp" line="41"/>
+      <source>You should set at least one OCR language in the application settings</source>
+      <translation>Você deve definir pelo menos um idioma OCR nas configurações do aplicativo</translation>
+    </message>
+    <message>
+      <location filename="../../src/ocr/ocr.cpp" line="148"/>
+      <source>%1 is not a valid Tesseract parameter name.</source>
+      <translation>%1 não é um nome de parâmetro Tesseract válido.</translation>
+    </message>
+  </context>
+  <context>
+    <name>PopupWindow</name>
+    <message>
+      <location filename="../../src/popupwindow.ui" line="32"/>
+      <source>Swap languages</source>
+      <translation>Alternar idiomas</translation>
+    </message>
+    <message>
+      <location filename="../../src/popupwindow.ui" line="64"/>
+      <source>Copy source text to the clipboard</source>
+      <translation>Copiar texto original para a área de transferência</translation>
+    </message>
+    <message>
+      <location filename="../../src/popupwindow.ui" line="140"/>
+      <source>Copy all translation data to the clipboard</source>
+      <translation>Copiar todos os dados da tradução para a área de transferência</translation>
+    </message>
+    <message>
+      <location filename="../../src/popupwindow.ui" line="151"/>
+      <source>Copy translation to the clipboard</source>
+      <translation>Copiar tradução para a área de transferência</translation>
+    </message>
+  </context>
+  <context>
+    <name>PortalAutostartManager</name>
+    <message>
+      <location filename="../../src/settings/autostartmanager/portalautostartmanager.cpp" line="45"/>
+      <source>Allow %1 to manage autostart setting for itself.</source>
+      <translation>Permitir que o %1 gerencie a configuração de início automático para si mesmo.</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/autostartmanager/portalautostartmanager.cpp" line="66"/>
+      <source>Unable to subscribe to response from xdg-desktop-portal.</source>
+      <translation>Não é possível assinar a resposta de xdg-desktop-portal.</translation>
+    </message>
+  </context>
+  <context>
+    <name>QGitTag</name>
+    <message>
+      <location filename="../../src/qgittag/src/qgittag.cpp" line="144"/>
+      <source>Release number %1 is missing</source>
+      <translation>O número da versão %1 está ausente</translation>
+    </message>
+  </context>
+  <context>
+    <name>QHotkey</name>
+    <message>
+      <location filename="../../src/third-party/qhotkey/QHotkey/qhotkey.cpp" line="277"/>
+      <source>Failed to register %1. Error: %2</source>
+      <translation>Falha ao registrar %1. Erro: %2</translation>
+    </message>
+    <message>
+      <location filename="../../src/third-party/qhotkey/QHotkey/qhotkey.cpp" line="297"/>
+      <source>Failed to unregister %1. Error: %2</source>
+      <translation>Falha ao remover registro de %1. Erro: %2</translation>
+    </message>
+  </context>
+  <context>
+    <name>QOnlineTranslator</name>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="203"/>
+      <source>Selected source language %1 is not supported for %2</source>
+      <translation>O idioma de origem selecionado %1 não é suportado para %2</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="208"/>
+      <source>Selected translation language %1 is not supported for %2</source>
+      <translation>O idioma de tradução selecionado %1 não é suportado para %2</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="213"/>
+      <source>Selected ui language %1 is not supported for %2</source>
+      <translation>O idioma da interface selecionado %1 não é suportado para %2</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="230"/>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="239"/>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="274"/>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="283"/>
+      <source>%1 URL can&apos;t be empty.</source>
+      <translation>O URL %1 não pode estar vazio.</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="481"/>
+      <source>Automatically detect</source>
+      <translation>Detectar automaticamente</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="483"/>
+      <source>Afrikaans</source>
+      <translation>Africâner</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="485"/>
+      <source>Albanian</source>
+      <translation>Albanês</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="487"/>
+      <source>Amharic</source>
+      <translation>Amárico</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="489"/>
+      <source>Arabic</source>
+      <translation>Árabe</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="491"/>
+      <source>Armenian</source>
+      <translation>Arménio</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="493"/>
+      <source>Azeerbaijani</source>
+      <translation>Azerbaijano</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="495"/>
+      <source>Basque</source>
+      <translation>Basco</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="497"/>
+      <source>Bashkir</source>
+      <translation>Basquir</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="499"/>
+      <source>Belarusian</source>
+      <translation>Bielo-russo</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="501"/>
+      <source>Bengali</source>
+      <translation>Bengali</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="503"/>
+      <source>Bosnian</source>
+      <translation>Bósnio</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="505"/>
+      <source>Bulgarian</source>
+      <translation>Búlgaro</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="507"/>
+      <source>Catalan</source>
+      <translation>Catalão</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="509"/>
+      <source>Cantonese</source>
+      <translation>Cantonês</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="511"/>
+      <source>Cebuano</source>
+      <translation>Cebuano</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="513"/>
+      <source>Chinese (Simplified)</source>
+      <translation>Chinês (Simplificado)</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="515"/>
+      <source>Chinese (Traditional)</source>
+      <translation>Chinês (Tradicional)</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="517"/>
+      <source>Corsican</source>
+      <translation>Corso</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="519"/>
+      <source>Croatian</source>
+      <translation>Croata</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="521"/>
+      <source>Czech</source>
+      <translation>Tcheco</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="523"/>
+      <source>Danish</source>
+      <translation>Dinamarquês</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="525"/>
+      <source>Dutch</source>
+      <translation>Holandês</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="527"/>
+      <source>English</source>
+      <translation>Inglês</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="529"/>
+      <source>Esperanto</source>
+      <translation>Esperanto</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="531"/>
+      <source>Estonian</source>
+      <translation>Estoniano</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="533"/>
+      <source>Fijian</source>
+      <translation>Fijiano</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="535"/>
+      <source>Filipino</source>
+      <translation>Filipino</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="537"/>
+      <source>Finnish</source>
+      <translation>Finlandês</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="539"/>
+      <source>French</source>
+      <translation>Francês</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="541"/>
+      <source>Frisian</source>
+      <translation>Frísio</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="543"/>
+      <source>Galician</source>
+      <translation>Galego</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="545"/>
+      <source>Georgian</source>
+      <translation>Georgiano</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="547"/>
+      <source>German</source>
+      <translation>Alemão</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="549"/>
+      <source>Greek</source>
+      <translation>Grego</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="551"/>
+      <source>Gujarati</source>
+      <translation>Guzerate</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="553"/>
+      <source>Haitian Creole</source>
+      <translation>Crioulo haitiano</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="555"/>
+      <source>Hausa</source>
+      <translation>Hauçá</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="557"/>
+      <source>Hawaiian</source>
+      <translation>Havaiano</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="559"/>
+      <source>Hebrew</source>
+      <translation>Hebraico</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="561"/>
+      <source>Hill Mari</source>
+      <translation>Hill Mari</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="563"/>
+      <source>Hindi</source>
+      <translation>Hindu</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="565"/>
+      <source>Hmong</source>
+      <translation>Hmong</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="567"/>
+      <source>Hungarian</source>
+      <translation>Húngaro</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="569"/>
+      <source>Icelandic</source>
+      <translation>Islandês</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="571"/>
+      <source>Igbo</source>
+      <translation>Igbo</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="573"/>
+      <source>Indonesian</source>
+      <translation>Indonésio</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="575"/>
+      <source>Irish</source>
+      <translation>Irlandês</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="577"/>
+      <source>Italian</source>
+      <translation>Italiano</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="579"/>
+      <source>Japanese</source>
+      <translation>Japonês</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="581"/>
+      <source>Javanese</source>
+      <translation>Javanês</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="583"/>
+      <source>Kannada</source>
+      <translation>Canarês</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="585"/>
+      <source>Kazakh</source>
+      <translation>Cazaque</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="587"/>
+      <source>Khmer</source>
+      <translation>Khmer</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="589"/>
+      <source>Kinyarwanda</source>
+      <translation>Kinyarwanda</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="591"/>
+      <source>Klingon</source>
+      <translation>Klingon</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="593"/>
+      <source>Klingon (PlqaD)</source>
+      <translation>Klingon (PlqaD)</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="595"/>
+      <source>Korean</source>
+      <translation>Coreano</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="597"/>
+      <source>Kurdish</source>
+      <translation>Curdo</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="599"/>
+      <source>Kyrgyz</source>
+      <translation>Quirguiz</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="601"/>
+      <source>Lao</source>
+      <translation>Laosiano</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="603"/>
+      <source>Latin</source>
+      <translation>Latim</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="605"/>
+      <source>Latvian</source>
+      <translation>Letão</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="607"/>
+      <source>Levantine Arabic</source>
+      <translation>Árabe Levantino</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="609"/>
+      <source>Lithuanian</source>
+      <translation>Lituano</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="611"/>
+      <source>Luxembourgish</source>
+      <translation>Luxemburguês</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="613"/>
+      <source>Macedonian</source>
+      <translation>Macedônio</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="615"/>
+      <source>Malagasy</source>
+      <translation>Malgaxe</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="617"/>
+      <source>Malay</source>
+      <translation>Malaio</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="619"/>
+      <source>Malayalam</source>
+      <translation>Malaiala</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="621"/>
+      <source>Maltese</source>
+      <translation>Maltês</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="623"/>
+      <source>Maori</source>
+      <translation>Maori</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="625"/>
+      <source>Marathi</source>
+      <translation>Marata</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="627"/>
+      <source>Mari</source>
+      <translation>Mari</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="629"/>
+      <source>Mongolian</source>
+      <translation>Mongol</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="631"/>
+      <source>Myanmar</source>
+      <translation>Birmanês</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="633"/>
+      <source>Nepali</source>
+      <translation>Nepalês</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="635"/>
+      <source>Norwegian</source>
+      <translation>Norueguês</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="637"/>
+      <source>Oriya</source>
+      <translation>Oriya</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="639"/>
+      <source>Chichewa</source>
+      <translation>Chicheua</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="641"/>
+      <source>Papiamento</source>
+      <translation>Papiamento</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="643"/>
+      <source>Pashto</source>
+      <translation>Pachto</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="645"/>
+      <source>Persian</source>
+      <translation>Persa</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="647"/>
+      <source>Polish</source>
+      <translation>Polonês</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="649"/>
+      <source>Portuguese</source>
+      <translation>Português</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="651"/>
+      <source>Punjabi</source>
+      <translation>Punjabi</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="653"/>
+      <source>Queretaro Otomi</source>
+      <translation>Otomi</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="655"/>
+      <source>Romanian</source>
+      <translation>Romeno</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="657"/>
+      <source>Russian</source>
+      <translation>Russo</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="659"/>
+      <source>Samoan</source>
+      <translation>Samoano</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="661"/>
+      <source>Scots Gaelic</source>
+      <translation>Gaélico Escocês</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="663"/>
+      <source>Serbian (Cyrillic)</source>
+      <translation>Sérvio (Cirílico)</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="665"/>
+      <source>Serbian (Latin)</source>
+      <translation>Sérvio (Latim)</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="667"/>
+      <source>Sesotho</source>
+      <translation>Sesoto</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="669"/>
+      <source>Shona</source>
+      <translation>Xona</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="671"/>
+      <source>Sindhi</source>
+      <translation>Sindi</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="673"/>
+      <source>Sinhala</source>
+      <translation>Cingalês</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="675"/>
+      <source>Slovak</source>
+      <translation>Eslovaco</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="677"/>
+      <source>Slovenian</source>
+      <translation>Esloveno</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="679"/>
+      <source>Somali</source>
+      <translation>Somali</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="681"/>
+      <source>Spanish</source>
+      <translation>Espanhol</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="683"/>
+      <source>Sundanese</source>
+      <translation>Sundanês</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="685"/>
+      <source>Swahili</source>
+      <translation>Suaíle</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="687"/>
+      <source>Swedish</source>
+      <translation>Sueco</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="689"/>
+      <source>Tagalog</source>
+      <translation>Tagalo</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="691"/>
+      <source>Tahitian</source>
+      <translation>Taitiano</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="693"/>
+      <source>Tajik</source>
+      <translation>Tadjique</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="695"/>
+      <source>Tamil</source>
+      <translation>Tâmil</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="697"/>
+      <source>Tatar</source>
+      <translation>Tártaro</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="699"/>
+      <source>Telugu</source>
+      <translation>Telugo</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="701"/>
+      <source>Thai</source>
+      <translation>Tailandês</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="703"/>
+      <source>Tongan</source>
+      <translation>Tonganês</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="705"/>
+      <source>Turkish</source>
+      <translation>Turco</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="707"/>
+      <source>Turkmen</source>
+      <translation>Turcomano</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="709"/>
+      <source>Udmurt</source>
+      <translation>Udmurte</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="711"/>
+      <source>Uighur</source>
+      <translation>Uighur</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="713"/>
+      <source>Ukrainian</source>
+      <translation>Ucraniano</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="715"/>
+      <source>Urdu</source>
+      <translation>Urdu</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="717"/>
+      <source>Uzbek</source>
+      <translation>Uzbeque</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="719"/>
+      <source>Vietnamese</source>
+      <translation>Vietnamita</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="721"/>
+      <source>Welsh</source>
+      <translation>Galês</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="723"/>
+      <source>Xhosa</source>
+      <translation>Xhosa</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="725"/>
+      <source>Yiddish</source>
+      <translation>Iídiche</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="727"/>
+      <source>Yoruba</source>
+      <translation>Ioruba</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="729"/>
+      <source>Yucatec Maya</source>
+      <translation>Iucateque</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="731"/>
+      <source>Zulu</source>
+      <translation>Zulu</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1250"/>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1259"/>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1342"/>
+      <source>Error: Engine systems have detected suspicious traffic from your computer network. Please try your request again later.</source>
+      <translation>Erro: Os mecanismo de tradução detectaram tráfego suspeito na rede da sua máquina. Tente novamente mais tarde.</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1271"/>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1422"/>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1615"/>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1709"/>
+      <source>Error: Unable to parse autodetected language</source>
+      <translation>Erro: Não foi possível interpretar o idioma detectado automaticamente</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1349"/>
+      <source>Error: Unable to find Yandex SID in web version.</source>
+      <translation>Erro: Não foi possível encontrar o Yandex SID na versão web.</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1356"/>
+      <source>Error: Unable to extract Yandex SID from web version.</source>
+      <translation>Erro: Não foi possível extrair o Yandex SID da versão web.</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1536"/>
+      <source>Error: Unable to find Bing credentials in web version.</source>
+      <translation>Erro: Não foi possível encontrar credenciais do Bing na versão web.</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1543"/>
+      <source>Error: Unable to extract Bing key from web version.</source>
+      <translation>Erro: Não foi possível extrair a chave do Bing da versão web.</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1551"/>
+      <source>Error: Unable to extract Bing token from web version.</source>
+      <translation>Erro: Não foi possível extrair o token do Bing da versão web.</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1559"/>
+      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1567"/>
+      <source>Error: Unable to extract additional Bing information from web version.</source>
+      <translation>Erro: Não foi possível extrair informações adicionais do Bing da versão web.</translation>
+    </message>
+  </context>
+  <context>
+    <name>QOnlineTts</name>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetts.cpp" line="51"/>
+      <source>Selected engine %1 does not support voice settings</source>
+      <translation>O mecanismo selecionado %1 não suporta configurações de voz</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetts.cpp" line="56"/>
+      <source>Selected engine %1 does not support emotion settings</source>
+      <translation>O mecanismo selecionado %1 não suporta configurações de emoção</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetts.cpp" line="125"/>
+      <source>%1 engine does not support TTS</source>
+      <translation>O mecanismo %1 não suporta TTS</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetts.cpp" line="196"/>
+      <source>Selected language %1 is not supported for %2</source>
+      <translation>O idioma selecionado %1 não é suportado para %2</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetts.cpp" line="208"/>
+      <source>Selected voice %1 is not supported for %2</source>
+      <translation>A voz selecionada %1 não é suportada para %2</translation>
+    </message>
+    <message>
+      <location filename="../../src/qonlinetranslator/src/qonlinetts.cpp" line="220"/>
+      <source>Selected emotion %1 is not supported for %2</source>
+      <translation>A emoção selecionada %1 não é suportada para %2</translation>
+    </message>
+  </context>
+  <context>
+    <name>SettingsDialog</name>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="14"/>
+      <source>Settings</source>
+      <translation>Configurações</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="49"/>
+      <location filename="../../src/settings/settingsdialog.ui" line="144"/>
+      <source>General</source>
+      <translation>Geral</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="58"/>
+      <source>Interface</source>
+      <translation>Interface</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="67"/>
+      <location filename="../../src/settings/settingsdialog.ui" line="651"/>
+      <source>Translation</source>
+      <translation>Tradução</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="85"/>
+      <source>Speech synthesis</source>
+      <translation>Síntese de fala</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="94"/>
+      <source>Connection</source>
+      <translation>Conexão</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="103"/>
+      <source>Shortcuts</source>
+      <translation>Atalhos</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="112"/>
+      <source>About</source>
+      <translation>Sobre</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="210"/>
+      <location filename="../../src/settings/settingsdialog.ui" line="359"/>
+      <source>Pop-up window</source>
+      <translation>Janela pop-up</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="215"/>
+      <source>Main window</source>
+      <translation>Janela principal</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="156"/>
+      <source>Language:</source>
+      <translation>Idioma:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.cpp" line="72"/>
+      <location filename="../../src/settings/settingsdialog.cpp" line="94"/>
+      <location filename="../../src/settings/settingsdialog.cpp" line="95"/>
+      <source>&lt;System language&gt;</source>
+      <translation>&lt;Idioma do Sistema&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="260"/>
+      <source>Show tray icon</source>
+      <translation>Mostrar ícone na bandeja</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="273"/>
+      <source>Start minimized</source>
+      <translation>Minimizar na inicialização</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="199"/>
+      <source>Translation mode:</source>
+      <translation>Modo de tradução:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="206"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A window for translating selected text. If the application is minimized, the main window will always be used.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Uma janela para traduzir o texto selecionado. Se a aplicação estiver minimizada, a janela principal sempre será usada.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="280"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Run the application at system startup&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Executar o aplicativo na inicialização do sistema&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="283"/>
+      <source>Launch at startup</source>
+      <translation>Executar na inicialização</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="270"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Start application minimized to the system tray&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Iniciar o aplicativo minimizado na bandeja do sistema&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="419"/>
+      <source>Opacity:</source>
+      <translation>Opacidade:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="392"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Pop-up window opacity&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Opacidade da janela pop-up&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="329"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Translation and source text font&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Fonte da tradução e texto de origem&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="343"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Font size of translation and source text&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tamanho da fonte da tradução e do texto fonte&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="433"/>
+      <source>Height:</source>
+      <translation>Altura:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="365"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Pop-up window height in pixels&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Altura da janela pop-up em pixels&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="375"/>
+      <source>Width:</source>
+      <translation>Largura:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="382"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Pop-up window width in pixels&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Largura da janela pop-up em pixels&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="228"/>
+      <source>Translation notification timeout:</source>
+      <translation>Tempo de notificação da tradução:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="241"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Notification with translation display time&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Notificação com o tempo de exibição da tradução&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="244"/>
+      <location filename="../../src/settings/settingsdialog.ui" line="449"/>
+      <source> sec</source>
+      <translation> seg.</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="482"/>
+      <location filename="../../src/settings/settingsdialog.ui" line="506"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Languages text on buttons&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Texto de idiomas nos botões&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="526"/>
+      <source>Tray icon</source>
+      <translation>Ícone da bandeja</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="532"/>
+      <source>Icon:</source>
+      <translation>Ícone:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="613"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select icon&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Selecionar ícone&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="545"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;System tray icon&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ícone da bandeja do sistema&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="549"/>
+      <source>Default</source>
+      <translation>Padrão</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="558"/>
+      <source>Monochrome (dark theme)</source>
+      <translation>Monocromático (tema escuro)</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="567"/>
+      <source>Monochrome (light theme)</source>
+      <translation>Monocromático (tema claro)</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="576"/>
+      <source>Custom</source>
+      <translation>Personalizado</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="591"/>
+      <source>Custom:</source>
+      <translation>Personalizado:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1197"/>
+      <source>Zahar</source>
+      <translation>Zahar</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1202"/>
+      <source>Ermil</source>
+      <translation>Ermil</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1207"/>
+      <source>Jane</source>
+      <translation>Jane</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1212"/>
+      <source>Oksana</source>
+      <translation>Oksana</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1217"/>
+      <source>Alyss</source>
+      <translation>Alyss</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1222"/>
+      <source>Omazh</source>
+      <translation>Omazh</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1230"/>
+      <source>Emotional connotation:</source>
+      <translation>Conotação emocional:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1247"/>
+      <source>Neutral</source>
+      <translation>Neutro</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1252"/>
+      <source>Good</source>
+      <translation>Bom</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1257"/>
+      <source>Evil</source>
+      <translation>Mau</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="660"/>
+      <source>Enable source transliteration</source>
+      <translation>Habilitar transliteração da origem</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="670"/>
+      <source>Enable translation transliteration</source>
+      <translation>Habilitar transliteração de tradução</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="680"/>
+      <source>Enable source transcription</source>
+      <translation>Habilitar transcrição da fonte</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="690"/>
+      <source>Enable translation options</source>
+      <translation>Habilitar opções de tradução</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="697"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable or disable usage examples&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Habilitar ou desativar os exemplos de utilização&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="700"/>
+      <source>Enable examples</source>
+      <translation>Habilitar exemplos</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="720"/>
+      <source>Automatic language detection</source>
+      <translation>Detecção automática de idioma</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="726"/>
+      <source>Primary translation language:</source>
+      <translation>Idioma de tradução principal:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="740"/>
+      <source>Secondary translation language:</source>
+      <translation>Idioma de tradução secundário:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="747"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Language to which the text will be translated if it is in the language selected above&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Idioma para o qual o texto será traduzido se estiver no idioma selecionado acima&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="969"/>
+      <source>Directory with trained models</source>
+      <translation>Pasta com modelos treinados</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="938"/>
+      <source>Languages path:</source>
+      <translation>Caminho do idioma:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="945"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select OCR languages path&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Selecione o caminho dos idiomas OCR&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="931"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Loading additional languages will impact both speed and accuracy, as there is more work to do to decide on the applicable language, and there is more chance of hallucinating incorrect words.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Carregar idiomas adicionais terá um impacto na velocidade e precisão, à medida que há mais trabalho a fazer para decidir sobre o idioma aplicável, e há mais possibilidade de surgirem palavras incorretas.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="956"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open GitHub repository&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Abrir repositório no GitHub&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="959"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/tesseract-ocr/tessdata&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;Download more&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/tesseract-ocr/tessdata&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;Baixar mais&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1054"/>
+      <source>Screen capture</source>
+      <translation>Capturar tela</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1066"/>
+      <source>Remember region:</source>
+      <translation>Lembrar região:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1115"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show a magnifier next to the cursor&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar uma lupa próximo ao cursor&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1118"/>
+      <source>Show magnifier</source>
+      <translation>Mostrar lupa</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1138"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply a slight fog to the unselected part&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Aplicar um pequeno desfoque na parte não selecionada&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1141"/>
+      <source>Apply light mask</source>
+      <translation>Aplicar máscara de luz</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1082"/>
+      <source>Remember last</source>
+      <translation>Lembrar última</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="426"/>
+      <source>Show timeout:</source>
+      <translation>Mostrar tempo limite:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="446"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The number of seconds after which the window will be hidden if it has no focus&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;O número de segundos após os quais a janela ficará oculta se não tiver foco&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="816"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;LibreTranslate engine URL&lt;/p&gt;&lt;p&gt;All instances can be found here: https://github.com/LibreTranslate/LibreTranslate#mirrors&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;URL do mecanismo LibreTranslate&lt;/p&gt;&lt;p&gt;Todas as instâncias podem ser encontradas aqui: https://github.com/LibreTranslate/LibreTranslate#mirrors&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="871"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Lingva engine URL&lt;/p&gt;&lt;p&gt;All instances can be found here: https://github.com/TheDavidDelta/lingva-translate#instances&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;URL do mecanismo Lingva&lt;/p&gt;&lt;p&gt;Todas as instâncias podem ser encontradas aqui: https://github.com/TheDavidDelta/lingva-translate#instances&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1087"/>
+      <source>Remember always</source>
+      <translation>Lembrar sempre</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1128"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Finish capturing the fragment when the mouse button is released&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Termine de capturar o fragmento quando o botão do mouse for liberado&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1180"/>
+      <source>Voice:</source>
+      <translation>Voz:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1243"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Voice mood of the speech synthesis engine&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Humor da voz do mecanismo de síntese de fala&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1265"/>
+      <source>Speech test:</source>
+      <translation>Teste de pronuncia:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1277"/>
+      <source>This is an example of speech synthesis.</source>
+      <translation>Este é um exemplo de síntese de fala.</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1280"/>
+      <source>Test voice</source>
+      <translation>Testar voz</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1318"/>
+      <source>Proxy server</source>
+      <translation>Servidor proxy</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1324"/>
+      <source>Type:</source>
+      <translation>Tipo:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1341"/>
+      <source>Use system settings</source>
+      <translation>Use as configurações do sistema</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1351"/>
+      <source>Don&apos;t use a proxy</source>
+      <translation>Não usar um proxy</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1367"/>
+      <source>Host:</source>
+      <translation>Endereço:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1390"/>
+      <source>Port:</source>
+      <translation>Porta:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1425"/>
+      <source>Info: the proxy works only for text translation</source>
+      <translation>Nota: As configurações de proxy são válidas apenas para tradução de texto</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1435"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable or disable authentication&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ative ou desative a autenticação&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1438"/>
+      <source>Authentication</source>
+      <translation>Autenticação</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1448"/>
+      <source>Username:</source>
+      <translation>Nome de usuário:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1458"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Proxy username for authentication&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Nome de usuário do proxy para autenticação&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1468"/>
+      <source>Password:</source>
+      <translation>Senha:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="220"/>
+      <source>Notification</source>
+      <translation>Notificação</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="163"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Interface language&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Idioma da interface&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="257"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Display icon in the system tray&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Exibir ícone na bandeja do sistema&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="170"/>
+      <source>Main window orientation:</source>
+      <translation>Orientação da janela principal:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="177"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Orientation of the main window layout&lt;br/&gt;When using &lt;span style=&quot; font-style:italic;&quot;&gt;Auto&lt;/span&gt;, the window orientation will match the screen orientation&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Orientação do layout da janela principal&lt;br/&gt;ao usar &lt;span style=&quot; font-style:italic;&quot;&gt;Automático&lt;/span&gt;, a orientação da janela corresponderá à orientação da tela&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="181"/>
+      <source>Auto</source>
+      <extracomment>Orientation</extracomment>
+      <translation>Automático</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="186"/>
+      <source>Portrait</source>
+      <extracomment>Orientation</extracomment>
+      <translation>Retrato</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="191"/>
+      <source>Landscape</source>
+      <extracomment>Orientation</extracomment>
+      <translation>Paisagem</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="316"/>
+      <source>Font</source>
+      <translation>Fonte</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="322"/>
+      <source>Name:</source>
+      <translation>Nome:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="336"/>
+      <source>Size:</source>
+      <translation>Tamanho:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="469"/>
+      <source>Language format</source>
+      <translation>Formato do idioma</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="475"/>
+      <source>Main window:</source>
+      <translation>Janela principal:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="486"/>
+      <location filename="../../src/settings/settingsdialog.ui" line="510"/>
+      <source>Full name</source>
+      <translation>Nome completo</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="491"/>
+      <location filename="../../src/settings/settingsdialog.ui" line="515"/>
+      <source>ISO 639-1 code</source>
+      <translation>Código ISO 639-1</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="499"/>
+      <source>Pop-up:</source>
+      <translation>Popup:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="657"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable or disable source transliteration&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Habilitar ou desativar a transliteração da origem&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="667"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable or disable translation transliteration&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Habilitar ou desativar a transliteração de tradução&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="677"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable or disable source transcription&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Habilitar ou desativar a transcrição da origem&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="687"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable or disable translation options&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Habilitar ou desativar opções de tradução&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="707"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Replace each sequence of whitespaces (this includes the ASCII characters &apos;\t&apos;, &apos;\n&apos;, &apos;\v&apos;, &apos;\f&apos;, &apos;\r&apos;, and &apos; &apos;) with a single space in queries&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Substitui cada sequência de espaços em branco (isto inclui os caracteres ASCII &apos;\t&apos;, &apos;\n&apos;, &apos;\v&apos;, &apos;\f&apos;, &apos;\r&apos;, e &apos; &apos;) com um único espaço nas consultas&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="710"/>
+      <source>Simplify source</source>
+      <translation>Simplificar fonte</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="733"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Language to which text will be translated when autodetecting&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Idioma para o qual o texto será traduzido durante a autodetecção&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="754"/>
+      <location filename="../../src/settings/settingsdialog.ui" line="764"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Automatically switch to &lt;span style=&quot; font-style:italic;&quot;&gt;Auto&lt;/span&gt; when using OCR and global shortcuts&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Automaticamente mudar para &lt;span style=&quot; font-style:italic;&quot;&gt;Automático&lt;/span&gt; quando usar atalhos globais e OCR&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="757"/>
+      <source>Force source language detection</source>
+      <translation>Forçar detecção de idioma de origem</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="767"/>
+      <source>Force translation language detection</source>
+      <translation>Forçar detecção do idioma de tradução</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="790"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;LibreTranslate instance API key&lt;/p&gt;&lt;p&gt;Free instances listed here doesn&apos;t require a key, so field can be empty&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Chave API da instância do LibreTranslate&lt;/p&gt;&lt;p&gt;Instâncias grátis listadas aqui não necessitam de uma chave, assim o campo pode ficar vazio&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="803"/>
+      <source>API key:</source>
+      <translation>Chave API:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="925"/>
+      <source>Languages</source>
+      <translation>Idiomas</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="985"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Replace all single line breaks with a space after text recognition&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Substitua todas as quebras de linha simples por um espaço após reconhecimento de texto&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="988"/>
+      <source>Convert line breaks</source>
+      <translation>Converter quebras de linha</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1073"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When to remember the last selected region&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Quando lembrar a última região selecionada&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1095"/>
+      <source>Capture delay:</source>
+      <translation>Atraso de captura:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1102"/>
+      <source>Delay before screen capture</source>
+      <translation>Atraso antes da captura de tela</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1105"/>
+      <source> ms</source>
+      <translation> ms</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1131"/>
+      <source>Confirm on release</source>
+      <translation>Confirmar ao liberar</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1193"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Voice of the speech synthesis engine&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Voz do mecanismo de síntese de fala&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1274"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Text to test speech&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Texto para testar a síntese de fala&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1491"/>
+      <source>Info: the password is saved unencrypted</source>
+      <translation>Nota: a senha é salva sem criptografia</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1406"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Proxy port&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Porta do proxy&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1377"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Proxy host name&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Nome do endereço de proxy&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1337"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Proxy type&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tipo de proxy&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1527"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Register global shortcuts in system&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Registrar atalhos globais no sistema&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1530"/>
+      <source>Enable global shortcucts</source>
+      <translation>Ativar atalhos globais</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1559"/>
+      <source>Shortcut</source>
+      <translation>Atalho</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1549"/>
+      <source>Reset all</source>
+      <translation>Restaurar padrões</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="603"/>
+      <source>Path to the icon or icon name from theme</source>
+      <translation>Caminho para o ícone ou nome do ícone do tema</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1478"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Proxy password for authentication&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Senha do proxy para autenticação&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1565"/>
+      <source>Key sequence:</source>
+      <translation>Sequência de teclas:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1579"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Accept shortcut&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Aceitar atalho&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1582"/>
+      <source>Accept</source>
+      <translation>Aceitar</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1593"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Clear shortcut&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Limpar atalho&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1596"/>
+      <source>Clear</source>
+      <translation>Limpar</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1610"/>
+      <source>Reset</source>
+      <translation>Resetar</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1656"/>
+      <source>Version:</source>
+      <translation>Versão:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1546"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Reset all shortcuts to defaults&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Restaurar todos os atalhos para o padrão&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1572"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The key sequence for the selected action&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A sequência de teclas para a ação selecionada&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1607"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Reset shortcut to default&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Restaurar atalho para o padrão&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1666"/>
+      <source>License:</source>
+      <translation>Licença:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1680"/>
+      <source>Source code:</source>
+      <translation>Código fonte:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1720"/>
+      <source>Flag icons:</source>
+      <translation>Ícones das bandeiras:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.cpp" line="50"/>
+      <source>Portable mode</source>
+      <translation>Modo portátil</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.cpp" line="63"/>
+      <source>Use %1 from the application folder to store settings</source>
+      <translation>Use %1 da pasta do aplicativo para armazenar as configurações</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.cpp" line="137"/>
+      <source>Updates</source>
+      <translation>Atualizações</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.cpp" line="144"/>
+      <source>Check for updates:</source>
+      <translation>Verificar atualizações:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.cpp" line="148"/>
+      <source>Every day</source>
+      <translation>Diariamente</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.cpp" line="149"/>
+      <source>Every week</source>
+      <translation>Semanalmente</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.cpp" line="150"/>
+      <source>Every month</source>
+      <translation>Mensalmente</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.ui" line="1077"/>
+      <location filename="../../src/settings/settingsdialog.cpp" line="151"/>
+      <source>Never</source>
+      <translation>Nunca</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.cpp" line="127"/>
+      <source>Icons:</source>
+      <translation>Ícones:</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.cpp" line="155"/>
+      <source>Check now</source>
+      <translation>Verificar agora</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.cpp" line="156"/>
+      <source>Check for updates now</source>
+      <translation>Verificar atualizações agora</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.cpp" line="169"/>
+      <source>Happy New Year!</source>
+      <translation>Feliz Ano Novo!</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.cpp" line="183"/>
+      <source>The OCR parameter fields can not be empty.</source>
+      <translation>Os campos do parâmetro OCR não podem estar vazios.</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.cpp" line="184"/>
+      <source>Do you want to discard the invalid parameters?</source>
+      <translation>Você quer descartar os parâmetros inválidos?</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.cpp" line="333"/>
+      <source>Select icon</source>
+      <translation>Selecione o ícone</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.cpp" line="333"/>
+      <source>Images (*.png *.ico *.svg *.jpg);;All files()</source>
+      <translation>Imagens (*.png *.ico *.svg *.jpg);;Todos os arquivos()</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.cpp" line="346"/>
+      <source>Select OCR languages path</source>
+      <translation>Selecione o caminho dos idiomas OCR</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.cpp" line="381"/>
+      <source>Nothing to play</source>
+      <translation>Nada para reproduzir</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.cpp" line="381"/>
+      <source>Playback text is empty</source>
+      <translation>O texto para reprodução está vazio</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.cpp" line="391"/>
+      <source>Unable to detect language</source>
+      <translation>Não foi possível detectar o idioma</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.cpp" line="445"/>
+      <source>Checking for updates...</source>
+      <translation>Verificando atualizações...</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.cpp" line="467"/>
+      <source>Update available!</source>
+      <translation>Atualização disponível!</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.cpp" line="473"/>
+      <source>No updates available.</source>
+      <translation>Não há atualizações disponíveis.</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/settingsdialog.cpp" line="571"/>
+      <source>Back</source>
+      <translation>Voltar</translation>
+    </message>
+  </context>
+  <context>
+    <name>ShortcutsModel</name>
+    <message>
+      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="138"/>
+      <source>Description</source>
+      <translation>Descrição</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="140"/>
+      <source>Shortcut</source>
+      <translation>Atalho</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="34"/>
+      <source>Global</source>
+      <translation>Global</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="36"/>
+      <source>Translate selected text</source>
+      <translation>Traduzir texto selecionado</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="39"/>
+      <source>Speak selected text</source>
+      <translation>Falar texto selecionado</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="42"/>
+      <source>Speak translation of selected text</source>
+      <translation>Falar tradução do texto selecionado</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="45"/>
+      <source>Stop text speaking</source>
+      <translation>Parar a pronúncia do texto</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="51"/>
+      <source>Show main window</source>
+      <translation>Exibir janela principal</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="54"/>
+      <source>Translate selected text and copy to clipboard</source>
+      <translation>Traduzir texto selecionado e copiar para área de transferência</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="57"/>
+      <source>Recognize text in screen area</source>
+      <translation>Reconhecer texto na área da tela</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="60"/>
+      <source>Translate text in screen area</source>
+      <translation>Traduzir texto na área da tela</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="63"/>
+      <source>Recognize text in screen area with delay</source>
+      <translation>Reconhecer texto na área da tela com atraso</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="66"/>
+      <source>Translate text in screen area with delay</source>
+      <translation>Traduzir texto na área da tela com atraso</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="70"/>
+      <source>Main window</source>
+      <translation>Janela principal</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="72"/>
+      <source>Translate</source>
+      <translation>Traduzir</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="75"/>
+      <source>Swap languages</source>
+      <translation>Alternar idiomas</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="78"/>
+      <source>Close window</source>
+      <translation>Fechar janela</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="82"/>
+      <source>Source text</source>
+      <translation>Texto original</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="48"/>
+      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="84"/>
+      <source>Speak / pause text speaking</source>
+      <translation>Falar / pausar texto falado</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="90"/>
+      <source>Speak / pause speaking</source>
+      <translation>Falar / pausar fala</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="88"/>
+      <source>Translation</source>
+      <translation>Tradução</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="93"/>
+      <source>Copy to clipboard</source>
+      <translation>Copiar para a área de transferência</translation>
+    </message>
+  </context>
+  <context>
+    <name>SnippingArea</name>
+    <message>
+      <location filename="../../src/ocr/snippingarea.cpp" line="93"/>
+      <source>Unable to snip screen area</source>
+      <translation>Não é possível recortar área da tela</translation>
+    </message>
+    <message>
+      <location filename="../../src/ocr/snippingarea.cpp" line="94"/>
+      <source>Received an invalid image of screen %1.</source>
+      <translation>Foi recebida uma imagem inválida da tela %1.</translation>
+    </message>
+    <message>
+      <location filename="../../src/ocr/snippingarea.cpp" line="653"/>
+      <source>Click and drag to draw a selection rectangle,
+or press Esc to quit</source>
+      <translation>Clique e arraste para desenhar um retângulo de seleção,
+ou pressione Esc para sair</translation>
+    </message>
+    <message>
+      <location filename="../../src/ocr/snippingarea.cpp" line="925"/>
+      <source>Confirm:</source>
+      <translation>Confirmar:</translation>
+    </message>
+    <message>
+      <location filename="../../src/ocr/snippingarea.cpp" line="927"/>
+      <source>Release left-click</source>
+      <translation>Soltar botão esquerdo</translation>
+    </message>
+    <message>
+      <location filename="../../src/ocr/snippingarea.cpp" line="927"/>
+      <location filename="../../src/ocr/snippingarea.cpp" line="929"/>
+      <source>Enter</source>
+      <translation>Enter</translation>
+    </message>
+    <message>
+      <location filename="../../src/ocr/snippingarea.cpp" line="929"/>
+      <source>Double-click</source>
+      <translation>Clique duplo</translation>
+    </message>
+    <message>
+      <location filename="../../src/ocr/snippingarea.cpp" line="931"/>
+      <source>Create new selection rectangle:</source>
+      <translation>Criar novo retângulo de seleção:</translation>
+    </message>
+    <message>
+      <location filename="../../src/ocr/snippingarea.cpp" line="932"/>
+      <source>Drag outside selection rectangle</source>
+      <translation>Arraste para fora do retângulo de seleção</translation>
+    </message>
+    <message>
+      <location filename="../../src/ocr/snippingarea.cpp" line="932"/>
+      <source>+ Shift: Magnifier</source>
+      <translation>+ Shift: Lupa</translation>
+    </message>
+    <message>
+      <location filename="../../src/ocr/snippingarea.cpp" line="935"/>
+      <source>Move selection rectangle:</source>
+      <translation>Mover retângulo de seleção:</translation>
+    </message>
+    <message>
+      <location filename="../../src/ocr/snippingarea.cpp" line="936"/>
+      <source>Drag inside selection rectangle</source>
+      <translation>Arrastar para dentro do retângulo de seleção</translation>
+    </message>
+    <message>
+      <location filename="../../src/ocr/snippingarea.cpp" line="936"/>
+      <source>Arrow keys</source>
+      <translation>Teclas de seta</translation>
+    </message>
+    <message>
+      <location filename="../../src/ocr/snippingarea.cpp" line="936"/>
+      <source>+ Shift: Move in 1 pixel steps</source>
+      <translation>+ Shift: Mover em 1 pixel</translation>
+    </message>
+    <message>
+      <location filename="../../src/ocr/snippingarea.cpp" line="938"/>
+      <source>Resize selection rectangle:</source>
+      <translation>Redimensionar retângulo de seleção:</translation>
+    </message>
+    <message>
+      <location filename="../../src/ocr/snippingarea.cpp" line="939"/>
+      <source>Drag handles</source>
+      <translation>Alças de arrasto</translation>
+    </message>
+    <message>
+      <location filename="../../src/ocr/snippingarea.cpp" line="939"/>
+      <source>Arrow keys + Alt</source>
+      <translation>Teclas de seta + Alt</translation>
+    </message>
+    <message>
+      <location filename="../../src/ocr/snippingarea.cpp" line="939"/>
+      <source>+ Shift: Resize in 1 pixel steps</source>
+      <translation>+ Shift: Redimensionar em 1 pixel</translation>
+    </message>
+    <message>
+      <location filename="../../src/ocr/snippingarea.cpp" line="941"/>
+      <source>Reset selection:</source>
+      <translation>Redefinir seleção:</translation>
+    </message>
+    <message>
+      <location filename="../../src/ocr/snippingarea.cpp" line="942"/>
+      <source>Right-click</source>
+      <translation>Clique direito</translation>
+    </message>
+    <message>
+      <location filename="../../src/ocr/snippingarea.cpp" line="945"/>
+      <source>Cancel:</source>
+      <translation>Cancelar:</translation>
+    </message>
+    <message>
+      <location filename="../../src/ocr/snippingarea.cpp" line="946"/>
+      <source>Esc key</source>
+      <translation>Tecla Esc</translation>
+    </message>
+  </context>
+  <context>
+    <name>SpeakButtons</name>
+    <message>
+      <location filename="../../src/speakbuttons.ui" line="24"/>
+      <source>Speak / pause text speaking</source>
+      <translation>Falar / pausar texto falado</translation>
+    </message>
+    <message>
+      <location filename="../../src/speakbuttons.ui" line="34"/>
+      <source>Stop text speaking</source>
+      <translation>Parar a pronúncia do texto</translation>
+    </message>
+    <message>
+      <location filename="../../src/speakbuttons.cpp" line="130"/>
+      <source>No text specified</source>
+      <translation>Nenhum texto especificado</translation>
+    </message>
+    <message>
+      <location filename="../../src/speakbuttons.cpp" line="130"/>
+      <source>Playback text is empty</source>
+      <translation>O texto para reprodução está vazio</translation>
+    </message>
+    <message>
+      <location filename="../../src/speakbuttons.cpp" line="137"/>
+      <source>Unable to generate URLs for TTS</source>
+      <translation>Não foi possível gerar URLs para TTS</translation>
+    </message>
+  </context>
+  <context>
+    <name>TesseractParametersTableWidget</name>
+    <message>
+      <location filename="../../src/settings/tesseractparameterstablewidget.cpp" line="29"/>
+      <source>Property</source>
+      <translation>Propriedade</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/tesseractparameterstablewidget.cpp" line="29"/>
+      <source>Value</source>
+      <translation>Valor</translation>
+    </message>
+  </context>
+  <context>
+    <name>TranslationEdit</name>
+    <message>
+      <location filename="../../src/translationedit.cpp" line="62"/>
+      <source>translation options:</source>
+      <translation>opções de tradução:</translation>
+    </message>
+    <message>
+      <location filename="../../src/translationedit.cpp" line="97"/>
+      <source>examples:</source>
+      <translation>exemplos:</translation>
+    </message>
+  </context>
+  <context>
+    <name>TrayIcon</name>
+    <message>
+      <location filename="../../src/mainwindow.cpp" line="945"/>
+      <source>Invalid tray icon</source>
+      <translation>Ícone da área de notificação inválido</translation>
+    </message>
+    <message>
+      <location filename="../../src/mainwindow.cpp" line="945"/>
+      <source>The specified icon &apos;%1&apos; is invalid. The default icon will be used.</source>
+      <translation>O ícone especificado &apos;%1&apos; é inválido. O ícone padrão será usado.</translation>
+    </message>
+    <message>
+      <location filename="../../src/trayicon.cpp" line="32"/>
+      <location filename="../../src/trayicon.cpp" line="56"/>
+      <source>Show window</source>
+      <translation>Exibir janela</translation>
+    </message>
+    <message>
+      <location filename="../../src/trayicon.cpp" line="33"/>
+      <location filename="../../src/trayicon.cpp" line="57"/>
+      <source>Settings</source>
+      <translation>Configurações</translation>
+    </message>
+    <message>
+      <location filename="../../src/trayicon.cpp" line="34"/>
+      <location filename="../../src/trayicon.cpp" line="58"/>
+      <source>Quit</source>
+      <translation>Sair</translation>
+    </message>
+    <message>
+      <location filename="../../src/trayicon.cpp" line="63"/>
+      <source>Translation result</source>
+      <translation>Resultado da tradução</translation>
+    </message>
+  </context>
+  <context>
+    <name>UnixAutostartManager</name>
+    <message>
+      <location filename="../../src/settings/autostartmanager/unixautostartmanager.cpp" line="48"/>
+      <source>Unable to create %1</source>
+      <translation>Não foi possível criar %1</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/autostartmanager/unixautostartmanager.cpp" line="55"/>
+      <source>Unable to copy %1 to %2</source>
+      <translation>Não foi possível copiar %1 para %2</translation>
+    </message>
+    <message>
+      <location filename="../../src/settings/autostartmanager/unixautostartmanager.cpp" line="60"/>
+      <source>Unable to remove %1 from %2</source>
+      <translation>Não foi possível remover %1 de %2</translation>
+    </message>
+  </context>
+  <context>
+    <name>UpdaterDialog</name>
+    <message>
+      <location filename="../../src/updaterdialog.ui" line="90"/>
+      <source>Cancel download</source>
+      <translation>Cancelar download</translation>
+    </message>
+    <message>
+      <location filename="../../src/updaterdialog.ui" line="93"/>
+      <source>Cancel</source>
+      <translation>Cancelar</translation>
+    </message>
+    <message>
+      <location filename="../../src/updaterdialog.ui" line="34"/>
+      <source>Download the installer to the Downloads folder</source>
+      <translation>Baixar o instalador na pasta de Downloads</translation>
+    </message>
+    <message>
+      <location filename="../../src/updaterdialog.ui" line="37"/>
+      <source>Download</source>
+      <translation>Baixar</translation>
+    </message>
+    <message>
+      <location filename="../../src/updaterdialog.ui" line="24"/>
+      <source>Exit the program and run the installer</source>
+      <translation>Sair do programa e executar o instalador</translation>
+    </message>
+    <message>
+      <location filename="../../src/updaterdialog.ui" line="27"/>
+      <source>Install</source>
+      <translation>Instalar</translation>
+    </message>
+    <message>
+      <location filename="../../src/updaterdialog.ui" line="44"/>
+      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A new version of Crow Translate is available! Updates add functionality and improve the stability of the application. Most often.&lt;br/&gt;You can also download the release manually from this &lt;a href=&quot;https://github.com/crow-translate/crow-translate/releases&quot;&gt;link&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Uma nova versão do Crow Tradutor está disponível! Atualizações adicionam funcionalidades e melhoram a estabilidade do aplicativo. Com bastante frequência.&lt;br/&gt;Você também pode baixar a versão manualmente a partir de &lt;a href=&quot;https://github.com/crow-translate/crow-translate/releases&quot;&gt;link&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+      <location filename="../../src/updaterdialog.ui" line="67"/>
+      <source>Close this window</source>
+      <translation>Fechar essa janela</translation>
+    </message>
+    <message>
+      <location filename="../../src/updaterdialog.ui" line="70"/>
+      <source>Update later</source>
+      <translation>Atualizar depois</translation>
+    </message>
+    <message>
+      <location filename="../../src/updaterdialog.ui" line="109"/>
+      <source>Current version:</source>
+      <translation>Versão Atual:</translation>
+    </message>
+    <message>
+      <location filename="../../src/updaterdialog.ui" line="129"/>
+      <source>Available version:</source>
+      <translation>Versão disponível:</translation>
+    </message>
+    <message>
+      <location filename="../../src/updaterdialog.cpp" line="59"/>
+      <location filename="../../src/updaterdialog.cpp" line="62"/>
+      <source>Changelog:</source>
+      <translation>Registro de alterações:</translation>
+    </message>
+    <message>
+      <location filename="../../src/updaterdialog.cpp" line="132"/>
+      <source>Downloading is complete</source>
+      <translation>O download está completo</translation>
+    </message>
+    <message>
+      <location filename="../../src/updaterdialog.cpp" line="88"/>
+      <source>Unable to write file</source>
+      <translation>Não foi possível gravar o arquivo</translation>
+    </message>
+  </context>
+  <context>
+    <name>WaylandGnomeScreenGrabber</name>
+    <message>
+      <location filename="../../src/ocr/screengrabbers/waylandgnomescreengrabber.cpp" line="60"/>
+      <source>GNOME failed to take screenshot.</source>
+      <translation>GNOME não conseguiu fazer captura de tela.</translation>
+    </message>
+  </context>
+  <context>
+    <name>WaylandPlasmaScreenGrabber</name>
+    <message>
+      <location filename="../../src/ocr/screengrabbers/waylandplasmascreengrabber.cpp" line="61"/>
+      <source>Unable to create pipe: %1.</source>
+      <translation>Não foi possível criar o pipe: %1.</translation>
+    </message>
+    <message>
+      <location filename="../../src/ocr/screengrabbers/waylandplasmascreengrabber.cpp" line="105"/>
+      <source>Unable to wait for socket readiness: %1.</source>
+      <translation>Não foi possível esperar pela prontidão do soquete: %1.</translation>
+    </message>
+    <message>
+      <location filename="../../src/ocr/screengrabbers/waylandplasmascreengrabber.cpp" line="110"/>
+      <source>Timeout reading from pipe.</source>
+      <translation>Tempo limite de leitura do pipe.</translation>
+    </message>
+    <message>
+      <location filename="../../src/ocr/screengrabbers/waylandplasmascreengrabber.cpp" line="116"/>
+      <source>Unable to read data from socket: %1.</source>
+      <translation>Não foi possível ler dados do socket: %1.</translation>
+    </message>
+  </context>
+  <context>
+    <name>WaylandPortalScreenGrabber</name>
+    <message>
+      <location filename="../../src/ocr/screengrabbers/waylandportalscreengrabber.cpp" line="72"/>
+      <source>Unable to subscribe to response from xdg-desktop-portal.</source>
+      <translation>Não é possível assinar a resposta de xdg-desktop-portal.</translation>
+    </message>
+    <message>
+      <location filename="../../src/ocr/screengrabbers/waylandportalscreengrabber.cpp" line="92"/>
+      <source>Received an empty path from xdg-desktop-portal.</source>
+      <translation>Caminho vazio recebido de xdg-desktop-portal.</translation>
+    </message>
+  </context>
+</TS>

--- a/data/translations/crow-translate_pt_PT.ts
+++ b/data/translations/crow-translate_pt_PT.ts
@@ -1,2490 +1,2490 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="pt-PT" sourcelanguage="en">
-  <context>
+<TS version="2.1" language="pt_PT" sourcelanguage="en">
+<context>
     <name>AbstractAutostartManager</name>
     <message>
-      <location filename="../../src/settings/autostartmanager/abstractautostartmanager.cpp" line="53"/>
-      <source>Unable to apply autostart settings</source>
-      <translation>Não foi possível aplicar as configurações de início automático</translation>
+        <location filename="../../src/settings/autostartmanager/abstractautostartmanager.cpp" line="53"/>
+        <source>Unable to apply autostart settings</source>
+        <translation>Não foi possível aplicar as definições de início automático</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>AbstractScreenGrabber</name>
     <message>
-      <location filename="../../src/ocr/screengrabbers/abstractscreengrabber.cpp" line="64"/>
-      <source>Unable to grab screen</source>
-      <translation>Não é possível capturar o ecrã</translation>
+        <location filename="../../src/ocr/screengrabbers/abstractscreengrabber.cpp" line="64"/>
+        <source>Unable to grab screen</source>
+        <translation>Não foi possível capturar o ecrã</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>AddLanguageDialog</name>
     <message>
-      <location filename="../../src/addlanguagedialog.ui" line="14"/>
-      <source>Add language</source>
-      <translation>Adicionar idioma</translation>
+        <location filename="../../src/addlanguagedialog.ui" line="14"/>
+        <source>Add language</source>
+        <translation>Adicionar idioma</translation>
     </message>
     <message>
-      <location filename="../../src/addlanguagedialog.ui" line="91"/>
-      <source>Available languages:</source>
-      <translation>Idiomas disponíveis:</translation>
+        <location filename="../../src/addlanguagedialog.ui" line="91"/>
+        <source>Available languages:</source>
+        <translation>Idiomas disponíveis:</translation>
     </message>
     <message>
-      <location filename="../../src/addlanguagedialog.ui" line="104"/>
-      <source>Current languages:</source>
-      <translation>Idiomas atuais:</translation>
+        <location filename="../../src/addlanguagedialog.ui" line="104"/>
+        <source>Current languages:</source>
+        <translation>Idiomas atuais:</translation>
     </message>
     <message>
-      <location filename="../../src/addlanguagedialog.cpp" line="36"/>
-      <source>Filter (%1)</source>
-      <translation>Filtro (%1)</translation>
+        <location filename="../../src/addlanguagedialog.cpp" line="36"/>
+        <source>Filter (%1)</source>
+        <translation>Filtro (%1)</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>AppSettings</name>
     <message>
-      <location filename="../../src/settings/appsettings.cpp" line="1196"/>
-      <source>Unknown language code: %1</source>
-      <translation>Código de idioma desconhecido: %1</translation>
+        <location filename="../../src/settings/appsettings.cpp" line="1196"/>
+        <source>Unknown language code: %1</source>
+        <translation>Código de idioma desconhecido: %1</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>Cli</name>
     <message>
-      <location filename="../../src/cli.cpp" line="53"/>
-      <source>Display all language codes.</source>
-      <translation>Mostra todos os códigos de idioma.</translation>
+        <location filename="../../src/cli.cpp" line="53"/>
+        <source>Display all language codes.</source>
+        <translation>Mostrar todos os códigos de idioma.</translation>
     </message>
     <message>
-      <location filename="../../src/cli.cpp" line="54"/>
-      <source>Specify the source language (by default, engine will try to determine the language on its own).</source>
-      <translation>Especifica o idioma de origem (por padrão, o mecanismo tentará determinar o idioma por si próprio).</translation>
+        <location filename="../../src/cli.cpp" line="54"/>
+        <source>Specify the source language (by default, engine will try to determine the language on its own).</source>
+        <translation>Especificar o idioma de origem (por defeito, o mecanismo tentará determinar o idioma por si próprio).</translation>
     </message>
     <message>
-      <location filename="../../src/cli.cpp" line="55"/>
-      <source>Specify the translation language(s), splitted by &apos;+&apos; (by default, the system language is used).</source>
-      <translation>Especifica o(s) idioma(s) de tradução, separados por &apos;+&apos; (por padrão, o idioma do sistema é usado).</translation>
+        <location filename="../../src/cli.cpp" line="55"/>
+        <source>Specify the translation language(s), splitted by &apos;+&apos; (by default, the system language is used).</source>
+        <translation>Especificar o(s) idioma(s) de tradução, separados por &apos;+&apos; (por defeito, o idioma do sistema é usado).</translation>
     </message>
     <message>
-      <location filename="../../src/cli.cpp" line="56"/>
-      <source>Specify the translator language (by default, the system language is used).</source>
-      <translation>Especifica o idioma de tradução (por padrão, o idioma do sistema é usado).</translation>
+        <location filename="../../src/cli.cpp" line="56"/>
+        <source>Specify the translator language (by default, the system language is used).</source>
+        <translation>Especificar o idioma de tradução (por defeito, o idioma do sistema é usado).</translation>
     </message>
     <message>
-      <location filename="../../src/cli.cpp" line="58"/>
-      <source>Speak the translation.</source>
-      <translation>Fala a tradução.</translation>
+        <location filename="../../src/cli.cpp" line="58"/>
+        <source>Speak the translation.</source>
+        <translation>Falar a tradução.</translation>
     </message>
     <message>
-      <location filename="../../src/cli.cpp" line="59"/>
-      <source>Speak the source.</source>
-      <translation>Fala o texto original.</translation>
+        <location filename="../../src/cli.cpp" line="59"/>
+        <source>Speak the source.</source>
+        <translation>Falar o texto original.</translation>
     </message>
     <message>
-      <location filename="../../src/cli.cpp" line="60"/>
-      <source>Read source text from files. Arguments will be interpreted as file paths.</source>
-      <translation>Lê o texto original em arquivos. Argumentos serão interpretados como caminhos de arquivo.</translation>
+        <location filename="../../src/cli.cpp" line="60"/>
+        <source>Read source text from files. Arguments will be interpreted as file paths.</source>
+        <translation>Ler o texto original nos ficheiros. Argumentos serão interpretados como caminhos do ficheiro.</translation>
     </message>
     <message>
-      <location filename="../../src/cli.cpp" line="61"/>
-      <source>Add stdin data to source text.</source>
-      <translation>Adiciona dados do stdin para o texto de origem.</translation>
+        <location filename="../../src/cli.cpp" line="61"/>
+        <source>Add stdin data to source text.</source>
+        <translation>Adicionar dados stdin para o texto de origem.</translation>
     </message>
     <message>
-      <location filename="../../src/cli.cpp" line="62"/>
-      <source>Do not print any text when using --%1 or --%2.</source>
-      <translation>Não imprimir nenhum texto quando estiver usando --%1 ou --%2.</translation>
+        <location filename="../../src/cli.cpp" line="62"/>
+        <source>Do not print any text when using --%1 or --%2.</source>
+        <translation>Não imprimir nenhum texto quando estiver a usar --%1 ou --%2.</translation>
     </message>
     <message>
-      <location filename="../../src/cli.cpp" line="64"/>
-      <source>Print output formatted as JSON.</source>
-      <translation>Imprimir saída formatada como JSON.</translation>
+        <location filename="../../src/cli.cpp" line="64"/>
+        <source>Print output formatted as JSON.</source>
+        <translation>Imprimir saída formatada como JSON.</translation>
     </message>
     <message>
-      <location filename="../../src/cli.cpp" line="68"/>
-      <source>Text to translate. By default, the translation will be done to the system language.</source>
-      <translation>Texto para traduzir. Por padrão, a tradução será feita no idioma do sistema.</translation>
+        <location filename="../../src/cli.cpp" line="68"/>
+        <source>Text to translate. By default, the translation will be done to the system language.</source>
+        <translation>Texto para traduzir. Por defeito, a tradução será feita no idioma do sistema.</translation>
     </message>
     <message>
-      <location filename="../../src/cli.cpp" line="366"/>
-      <source>Error: You can&apos;t use --%1 with --%2</source>
-      <translation>Erro: Você não pode usar --%1 com --%2</translation>
+        <location filename="../../src/cli.cpp" line="366"/>
+        <source>Error: You can&apos;t use --%1 with --%2</source>
+        <translation>Erro: Não pode usar --%1 com --%2</translation>
     </message>
     <message>
-      <location filename="../../src/cli.cpp" line="140"/>
-      <source>Error: Unknown engine</source>
-      <translation>Erro: Mecanismo desconhecido</translation>
+        <location filename="../../src/cli.cpp" line="140"/>
+        <source>Error: Unknown engine</source>
+        <translation>Erro: Motor desconhecido</translation>
     </message>
     <message>
-      <location filename="../../src/cli.cpp" line="124"/>
-      <source>Error: There is no text for translation</source>
-      <translation>Erro: Não há texto para tradução</translation>
+        <location filename="../../src/cli.cpp" line="124"/>
+        <source>Error: There is no text for translation</source>
+        <translation>Erro: Não há texto para tradução</translation>
     </message>
     <message>
-      <location filename="../../src/cli.cpp" line="63"/>
-      <source>Print only translations.</source>
-      <translation>Imprimir apenas traduções.</translation>
+        <location filename="../../src/cli.cpp" line="63"/>
+        <source>Print only translations.</source>
+        <translation>Imprimir apenas traduções.</translation>
     </message>
     <message>
-      <location filename="../../src/cli.cpp" line="57"/>
-      <source>Specify the translator engine (&apos;google&apos;, &apos;yandex&apos;, &apos;bing&apos;, &apos;libretranslate&apos; or &apos;lingva&apos;), Google is used by default.</source>
-      <translation>Especificar o mecanismo de tradução (&apos;google&apos;, &apos;yandex&apos;, &apos;bing&apos;, &apos;libretranslate&apos; ou &apos;lingva&apos;), Google é usado por padrão.</translation>
+        <location filename="../../src/cli.cpp" line="57"/>
+        <source>Specify the translator engine (&apos;google&apos;, &apos;yandex&apos;, &apos;bing&apos;, &apos;libretranslate&apos; or &apos;lingva&apos;), Google is used by default.</source>
+        <translation>Especificar o mecanismo de tradução (&apos;google&apos;, &apos;yandex&apos;, &apos;bing&apos;, &apos;libretranslate&apos; ou &apos;lingva&apos;), Google é usado por defeito.</translation>
     </message>
     <message>
-      <location filename="../../src/cli.cpp" line="67"/>
-      <source>A simple and lightweight translator that allows to translate and speak text using Google, Yandex, Bing, LibreTranslate and Lingva</source>
-      <translation>Um tradutor simples e leve que permite traduzir e reproduzir texto usando o Google, Yandex, Bing, LibreTranslate e Lingva</translation>
+        <location filename="../../src/cli.cpp" line="67"/>
+        <source>A simple and lightweight translator that allows to translate and speak text using Google, Yandex, Bing, LibreTranslate and Lingva</source>
+        <translation>Um tradutor leve e simples que permite traduzir e falar texto usando o Google, Yandex, Bing, LibreTranslate e Lingva</translation>
     </message>
     <message>
-      <location filename="../../src/cli.cpp" line="175"/>
-      <location filename="../../src/cli.cpp" line="264"/>
-      <location filename="../../src/cli.cpp" line="353"/>
-      <source>Error: %1</source>
-      <translation>Erro: %1</translation>
+        <location filename="../../src/cli.cpp" line="175"/>
+        <location filename="../../src/cli.cpp" line="264"/>
+        <location filename="../../src/cli.cpp" line="353"/>
+        <source>Error: %1</source>
+        <translation>Erro: %1</translation>
     </message>
     <message>
-      <location filename="../../src/cli.cpp" line="382"/>
-      <location filename="../../src/cli.cpp" line="403"/>
-      <source>Error: File does not exist: %1</source>
-      <translation>Erro: Arquivo não existe: %1</translation>
+        <location filename="../../src/cli.cpp" line="382"/>
+        <location filename="../../src/cli.cpp" line="403"/>
+        <source>Error: File does not exist: %1</source>
+        <translation>Erro: Ficheiro não existe: %1</translation>
     </message>
     <message>
-      <location filename="../../src/cli.cpp" line="387"/>
-      <location filename="../../src/cli.cpp" line="408"/>
-      <source>Error: Unable to open file: %1</source>
-      <translation>Erro: Não foi possível abrir o arquivo: %1</translation>
+        <location filename="../../src/cli.cpp" line="387"/>
+        <location filename="../../src/cli.cpp" line="408"/>
+        <source>Error: Unable to open file: %1</source>
+        <translation>Erro: Não foi possível abrir o ficheiro: %1</translation>
     </message>
     <message>
-      <location filename="../../src/cli.cpp" line="225"/>
-      <source>%1 - translation options:</source>
-      <translation>%1 - opções de tradução:</translation>
+        <location filename="../../src/cli.cpp" line="225"/>
+        <source>%1 - translation options:</source>
+        <translation>%1 - opções de tradução:</translation>
     </message>
     <message>
-      <location filename="../../src/cli.cpp" line="90"/>
-      <source>Error: For --%1 you must specify --%2 and/or --%3 options</source>
-      <translation>Erro: Para --%1, você deve especificar as opções --%2 e/ou --%3</translation>
+        <location filename="../../src/cli.cpp" line="90"/>
+        <source>Error: For --%1 you must specify --%2 and/or --%3 options</source>
+        <translation>Erro: Para --%1, tem de especificar as opções --%2 e/ou --%3</translation>
     </message>
     <message>
-      <location filename="../../src/cli.cpp" line="242"/>
-      <source>%1 - examples:</source>
-      <translation>%1 - exemplos:</translation>
+        <location filename="../../src/cli.cpp" line="242"/>
+        <source>%1 - examples:</source>
+        <translation>%1 - exemplos:</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>ContextMenu</name>
     <message>
-      <location filename="../../src/contextmenu.h" line="52"/>
-      <source>Search on Forvo.com</source>
-      <translation>Pesquisar em Forvo.com</translation>
+        <location filename="../../src/contextmenu.h" line="52"/>
+        <source>Search on Forvo.com</source>
+        <translation>Pesquisar no Forvo.com</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>D-Bus</name>
     <message>
-      <location filename="../../src/main.cpp" line="101"/>
-      <source>Unable to register D-Bus object for %1</source>
-      <translation>Não foi possível registrar objeto D-Bus para %1</translation>
+        <location filename="../../src/main.cpp" line="101"/>
+        <source>Unable to register D-Bus object for %1</source>
+        <translation>Não foi possível registar objeto D-Bus para %1</translation>
     </message>
     <message>
-      <location filename="../../src/main.cpp" line="77"/>
-      <source>D-Bus service %1 is already registered by another application</source>
-      <translation>O serviço D-Bus %1 já está registrado por outro aplicativo</translation>
+        <location filename="../../src/main.cpp" line="77"/>
+        <source>D-Bus service %1 is already registered by another application</source>
+        <translation>O serviço D-Bus %1 já está registado por outra aplicação</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>LanguageButtonsWidget</name>
     <message>
-      <location filename="../../src/languagebuttonswidget.cpp" line="461"/>
-      <source>Window width is larger than screen due to the languages on the panel.</source>
-      <translation>A largura da janela é maior que a tela devido aos idiomas no painel.</translation>
+        <location filename="../../src/languagebuttonswidget.cpp" line="461"/>
+        <source>Window width is larger than screen due to the languages on the panel.</source>
+        <translation>A largura da janela é maior que o ecrã devido aos idiomas no painel.</translation>
     </message>
     <message>
-      <location filename="../../src/languagebuttonswidget.cpp" line="462"/>
-      <source>Please reduce added languages.</source>
-      <translation>Por favor, reduza os idiomas adicionados.</translation>
+        <location filename="../../src/languagebuttonswidget.cpp" line="462"/>
+        <source>Please reduce added languages.</source>
+        <translation>Por favor, reduza os idiomas adicionados.</translation>
     </message>
     <message>
-      <location filename="../../src/languagebuttonswidget.cpp" line="538"/>
-      <location filename="../../src/languagebuttonswidget.cpp" line="540"/>
-      <source>Auto</source>
-      <translation>Automático</translation>
+        <location filename="../../src/languagebuttonswidget.cpp" line="538"/>
+        <location filename="../../src/languagebuttonswidget.cpp" line="540"/>
+        <source>Auto</source>
+        <translation>Auto</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>MainWindow</name>
     <message>
-      <location filename="../../src/mainwindow.ui" line="36"/>
-      <source>Copy source text to the clipboard</source>
-      <translation>Copiar texto original para a área de transferência</translation>
+        <location filename="../../src/mainwindow.ui" line="36"/>
+        <source>Copy source text to the clipboard</source>
+        <translation>Copiar texto original para a área de transferência</translation>
     </message>
     <message>
-      <location filename="../../src/mainwindow.ui" line="114"/>
-      <source>Source</source>
-      <translation>Origem</translation>
+        <location filename="../../src/mainwindow.ui" line="114"/>
+        <source>Source</source>
+        <translation>Origem</translation>
     </message>
     <message>
-      <location filename="../../src/mainwindow.ui" line="250"/>
-      <source>Copy translation to the clipboard</source>
-      <translation>Copiar tradução para a área de transferência</translation>
+        <location filename="../../src/mainwindow.ui" line="250"/>
+        <source>Copy translation to the clipboard</source>
+        <translation>Copiar tradução para a área de transferência</translation>
     </message>
     <message>
-      <location filename="../../src/mainwindow.ui" line="261"/>
-      <source>Copy all translation data to the clipboard</source>
-      <translation>Copiar todos os dados da tradução para a área de transferência</translation>
+        <location filename="../../src/mainwindow.ui" line="261"/>
+        <source>Copy all translation data to the clipboard</source>
+        <translation>Copiar todos os dados da tradução para a área de transferência</translation>
     </message>
     <message>
-      <location filename="../../src/mainwindow.ui" line="272"/>
-      <source>Translate screen area with delay</source>
-      <translation>Traduzir a área da tela com atraso</translation>
+        <location filename="../../src/mainwindow.ui" line="272"/>
+        <source>Translate screen area with delay</source>
+        <translation>Traduzir área de ecrã com atraso</translation>
     </message>
     <message>
-      <location filename="../../src/mainwindow.ui" line="283"/>
-      <source>Application settings</source>
-      <translation>Configurações da aplicação</translation>
+        <location filename="../../src/mainwindow.ui" line="283"/>
+        <source>Application settings</source>
+        <translation>Configurações da aplicação</translation>
     </message>
     <message>
-      <location filename="../../src/mainwindow.ui" line="93"/>
-      <source>Swap languages</source>
-      <translation>Alternar idiomas</translation>
+        <location filename="../../src/mainwindow.ui" line="93"/>
+        <source>Swap languages</source>
+        <translation>Alternar idiomas</translation>
     </message>
     <message>
-      <location filename="../../src/mainwindow.ui" line="47"/>
-      <source>Recognize screen area with delay</source>
-      <translation>Reconhecer área da tela com atraso</translation>
+        <location filename="../../src/mainwindow.ui" line="47"/>
+        <source>Recognize screen area with delay</source>
+        <translation>Reconhecer área de ecrã com atraso</translation>
     </message>
     <message>
-      <location filename="../../src/mainwindow.ui" line="70"/>
-      <source>Auto-translation</source>
-      <extracomment>The text should be short to fit in portrait orientation on phones.</extracomment>
-      <translation>Tradução automática</translation>
+        <location filename="../../src/mainwindow.ui" line="70"/>
+        <source>Auto-translation</source>
+        <extracomment>The text should be short to fit in portrait orientation on phones.</extracomment>
+        <translation>Auto-tradução</translation>
     </message>
     <message>
-      <location filename="../../src/mainwindow.ui" line="82"/>
-      <source>Cancel</source>
-      <translation>Cancelar</translation>
+        <location filename="../../src/mainwindow.ui" line="82"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
     </message>
     <message>
-      <location filename="../../src/mainwindow.ui" line="121"/>
-      <source>Clear</source>
-      <translation>Limpar</translation>
+        <location filename="../../src/mainwindow.ui" line="121"/>
+        <source>Clear</source>
+        <translation>Limpar</translation>
     </message>
     <message>
-      <location filename="../../src/mainwindow.ui" line="138"/>
-      <source>Translate</source>
-      <translation>Traduzir</translation>
+        <location filename="../../src/mainwindow.ui" line="138"/>
+        <source>Translate</source>
+        <translation>Traduzir</translation>
     </message>
     <message>
-      <location filename="../../src/mainwindow.ui" line="166"/>
-      <source>Translation</source>
-      <translation>Tradução</translation>
+        <location filename="../../src/mainwindow.ui" line="166"/>
+        <source>Translation</source>
+        <translation>Tradução</translation>
     </message>
     <message>
-      <location filename="../../src/mainwindow.cpp" line="406"/>
-      <source>Unable to detect language</source>
-      <translation>Não foi possível detectar o idioma</translation>
+        <location filename="../../src/mainwindow.cpp" line="406"/>
+        <source>Unable to detect language</source>
+        <translation>Não foi possível detetar o idioma</translation>
     </message>
     <message>
-      <location filename="../../src/mainwindow.cpp" line="458"/>
-      <source>Unable to translate text</source>
-      <translation>Não foi possível traduzir o texto</translation>
+        <location filename="../../src/mainwindow.cpp" line="458"/>
+        <source>Unable to translate text</source>
+        <translation>Não foi possível traduzir o texto</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>Ocr</name>
     <message>
-      <location filename="../../src/mainwindow.cpp" line="976"/>
-      <source>Unable to set OCR languages</source>
-      <translation>Não foi possível definir idiomas OCR</translation>
+        <location filename="../../src/mainwindow.cpp" line="976"/>
+        <source>Unable to set OCR languages</source>
+        <translation>Não foi possível definir idiomas OCR</translation>
     </message>
     <message>
-      <location filename="../../src/mainwindow.cpp" line="976"/>
-      <source>Unable to initialize Tesseract with %1</source>
-      <translation>Não foi possível inicializar Tesseract com %1</translation>
+        <location filename="../../src/mainwindow.cpp" line="976"/>
+        <source>Unable to initialize Tesseract with %1</source>
+        <translation>Não foi possível inicializar Tesseract com %1</translation>
     </message>
     <message>
-      <location filename="../../src/transitions/ocruninitializedtransition.cpp" line="41"/>
-      <source>OCR languages are not loaded</source>
-      <translation>Idiomas OCR não estão carregados</translation>
+        <location filename="../../src/transitions/ocruninitializedtransition.cpp" line="41"/>
+        <source>OCR languages are not loaded</source>
+        <translation>Idiomas OCR não estão carregados</translation>
     </message>
     <message>
-      <location filename="../../src/transitions/ocruninitializedtransition.cpp" line="41"/>
-      <source>You should set at least one OCR language in the application settings</source>
-      <translation>Você deve definir pelo menos um idioma OCR nas configurações do aplicativo</translation>
+        <location filename="../../src/transitions/ocruninitializedtransition.cpp" line="41"/>
+        <source>You should set at least one OCR language in the application settings</source>
+        <translation>Deve definir pelo menos um idioma OCR nas configurações da aplicação</translation>
     </message>
     <message>
-      <location filename="../../src/ocr/ocr.cpp" line="148"/>
-      <source>%1 is not a valid Tesseract parameter name.</source>
-      <translation>%1 não é um nome de parâmetro Tesseract válido.</translation>
+        <location filename="../../src/ocr/ocr.cpp" line="148"/>
+        <source>%1 is not a valid Tesseract parameter name.</source>
+        <translation>%1 não é um nome de parâmetro Tesseract válido.</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>PopupWindow</name>
     <message>
-      <location filename="../../src/popupwindow.ui" line="32"/>
-      <source>Swap languages</source>
-      <translation>Alternar idiomas</translation>
+        <location filename="../../src/popupwindow.ui" line="32"/>
+        <source>Swap languages</source>
+        <translation>Alternar idiomas</translation>
     </message>
     <message>
-      <location filename="../../src/popupwindow.ui" line="64"/>
-      <source>Copy source text to the clipboard</source>
-      <translation>Copiar texto original para a área de transferência</translation>
+        <location filename="../../src/popupwindow.ui" line="64"/>
+        <source>Copy source text to the clipboard</source>
+        <translation>Copiar texto original para a área de transferência</translation>
     </message>
     <message>
-      <location filename="../../src/popupwindow.ui" line="140"/>
-      <source>Copy all translation data to the clipboard</source>
-      <translation>Copiar todos os dados da tradução para a área de transferência</translation>
+        <location filename="../../src/popupwindow.ui" line="140"/>
+        <source>Copy all translation data to the clipboard</source>
+        <translation>Copiar todos os dados da tradução para a área de transferência</translation>
     </message>
     <message>
-      <location filename="../../src/popupwindow.ui" line="151"/>
-      <source>Copy translation to the clipboard</source>
-      <translation>Copiar tradução para a área de transferência</translation>
+        <location filename="../../src/popupwindow.ui" line="151"/>
+        <source>Copy translation to the clipboard</source>
+        <translation>Copiar tradução para a área de transferência</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>PortalAutostartManager</name>
     <message>
-      <location filename="../../src/settings/autostartmanager/portalautostartmanager.cpp" line="45"/>
-      <source>Allow %1 to manage autostart setting for itself.</source>
-      <translation>Permitir que o %1 gerencie a configuração de início automático para si mesmo.</translation>
+        <location filename="../../src/settings/autostartmanager/portalautostartmanager.cpp" line="45"/>
+        <source>Allow %1 to manage autostart setting for itself.</source>
+        <translation>Permitir que %1 gira a configuração de início automático para si mesmo.</translation>
     </message>
     <message>
-      <location filename="../../src/settings/autostartmanager/portalautostartmanager.cpp" line="66"/>
-      <source>Unable to subscribe to response from xdg-desktop-portal.</source>
-      <translation>Não é possível assinar a resposta de xdg-desktop-portal.</translation>
+        <location filename="../../src/settings/autostartmanager/portalautostartmanager.cpp" line="66"/>
+        <source>Unable to subscribe to response from xdg-desktop-portal.</source>
+        <translation>Não é possível subscrever a resposta de xdg-desktop-portal.</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>QGitTag</name>
     <message>
-      <location filename="../../src/qgittag/src/qgittag.cpp" line="144"/>
-      <source>Release number %1 is missing</source>
-      <translation>O número da versão %1 está ausente</translation>
+        <location filename="../../src/qgittag/src/qgittag.cpp" line="144"/>
+        <source>Release number %1 is missing</source>
+        <translation>Número da versão %1 está em falta</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>QHotkey</name>
     <message>
-      <location filename="../../src/third-party/qhotkey/QHotkey/qhotkey.cpp" line="277"/>
-      <source>Failed to register %1. Error: %2</source>
-      <translation>Falha ao registrar %1. Erro: %2</translation>
+        <location filename="../../src/third-party/qhotkey/QHotkey/qhotkey.cpp" line="277"/>
+        <source>Failed to register %1. Error: %2</source>
+        <translation>Falha ao registar %1. Erro: %2</translation>
     </message>
     <message>
-      <location filename="../../src/third-party/qhotkey/QHotkey/qhotkey.cpp" line="297"/>
-      <source>Failed to unregister %1. Error: %2</source>
-      <translation>Falha ao remover registro de %1. Erro: %2</translation>
+        <location filename="../../src/third-party/qhotkey/QHotkey/qhotkey.cpp" line="297"/>
+        <source>Failed to unregister %1. Error: %2</source>
+        <translation>Falha ao remover registo de %1. Erro: %2</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>QOnlineTranslator</name>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="203"/>
-      <source>Selected source language %1 is not supported for %2</source>
-      <translation>O idioma de origem selecionado %1 não é suportado para %2</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="203"/>
+        <source>Selected source language %1 is not supported for %2</source>
+        <translation>O idioma de origem selecionado %1 não é suportado para %2</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="208"/>
-      <source>Selected translation language %1 is not supported for %2</source>
-      <translation>O idioma de tradução selecionado %1 não é suportado para %2</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="208"/>
+        <source>Selected translation language %1 is not supported for %2</source>
+        <translation>O idioma de tradução selecionado %1 não é suportado para %2</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="213"/>
-      <source>Selected ui language %1 is not supported for %2</source>
-      <translation>O idioma da interface selecionado %1 não é suportado para %2</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="213"/>
+        <source>Selected ui language %1 is not supported for %2</source>
+        <translation>O idioma da interface selecionado %1 não é suportado para %2</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="230"/>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="239"/>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="274"/>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="283"/>
-      <source>%1 URL can&apos;t be empty.</source>
-      <translation>O URL %1 não pode estar vazio.</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="230"/>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="239"/>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="274"/>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="283"/>
+        <source>%1 URL can&apos;t be empty.</source>
+        <translation>O URL %1 não pode estar vazio.</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="481"/>
-      <source>Automatically detect</source>
-      <translation>Detectar automaticamente</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="481"/>
+        <source>Automatically detect</source>
+        <translation>Detetar automaticamente</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="483"/>
-      <source>Afrikaans</source>
-      <translation>Africâner</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="483"/>
+        <source>Afrikaans</source>
+        <translation>Africâner</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="485"/>
-      <source>Albanian</source>
-      <translation>Albanês</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="485"/>
+        <source>Albanian</source>
+        <translation>Albanês</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="487"/>
-      <source>Amharic</source>
-      <translation>Amárico</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="487"/>
+        <source>Amharic</source>
+        <translation>Amárico</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="489"/>
-      <source>Arabic</source>
-      <translation>Árabe</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="489"/>
+        <source>Arabic</source>
+        <translation>Árabe</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="491"/>
-      <source>Armenian</source>
-      <translation>Arménio</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="491"/>
+        <source>Armenian</source>
+        <translation>Arménio</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="493"/>
-      <source>Azeerbaijani</source>
-      <translation>Azerbaijano</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="493"/>
+        <source>Azeerbaijani</source>
+        <translation>Azerbaijano</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="495"/>
-      <source>Basque</source>
-      <translation>Basco</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="495"/>
+        <source>Basque</source>
+        <translation>Basco</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="497"/>
-      <source>Bashkir</source>
-      <translation>Basquir</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="497"/>
+        <source>Bashkir</source>
+        <translation>Basquir</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="499"/>
-      <source>Belarusian</source>
-      <translation>Bielo-russo</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="499"/>
+        <source>Belarusian</source>
+        <translation>Bielo-russo</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="501"/>
-      <source>Bengali</source>
-      <translation>Bengali</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="501"/>
+        <source>Bengali</source>
+        <translation>Bengali</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="503"/>
-      <source>Bosnian</source>
-      <translation>Bósnio</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="503"/>
+        <source>Bosnian</source>
+        <translation>Bósnio</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="505"/>
-      <source>Bulgarian</source>
-      <translation>Búlgaro</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="505"/>
+        <source>Bulgarian</source>
+        <translation>Búlgaro</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="507"/>
-      <source>Catalan</source>
-      <translation>Catalão</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="507"/>
+        <source>Catalan</source>
+        <translation>Catalão</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="509"/>
-      <source>Cantonese</source>
-      <translation>Cantonês</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="509"/>
+        <source>Cantonese</source>
+        <translation>Cantonês</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="511"/>
-      <source>Cebuano</source>
-      <translation>Cebuano</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="511"/>
+        <source>Cebuano</source>
+        <translation>Cebuano</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="513"/>
-      <source>Chinese (Simplified)</source>
-      <translation>Chinês (Simplificado)</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="513"/>
+        <source>Chinese (Simplified)</source>
+        <translation>Chinês (Simplificado)</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="515"/>
-      <source>Chinese (Traditional)</source>
-      <translation>Chinês (Tradicional)</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="515"/>
+        <source>Chinese (Traditional)</source>
+        <translation>Chinês (Tradicional)</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="517"/>
-      <source>Corsican</source>
-      <translation>Corso</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="517"/>
+        <source>Corsican</source>
+        <translation>Corso</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="519"/>
-      <source>Croatian</source>
-      <translation>Croata</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="519"/>
+        <source>Croatian</source>
+        <translation>Croata</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="521"/>
-      <source>Czech</source>
-      <translation>Tcheco</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="521"/>
+        <source>Czech</source>
+        <translation>Tcheco</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="523"/>
-      <source>Danish</source>
-      <translation>Dinamarquês</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="523"/>
+        <source>Danish</source>
+        <translation>Dinamarquês</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="525"/>
-      <source>Dutch</source>
-      <translation>Holandês</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="525"/>
+        <source>Dutch</source>
+        <translation>Holandês</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="527"/>
-      <source>English</source>
-      <translation>Inglês</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="527"/>
+        <source>English</source>
+        <translation>Inglês</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="529"/>
-      <source>Esperanto</source>
-      <translation>Esperanto</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="529"/>
+        <source>Esperanto</source>
+        <translation>Esperanto</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="531"/>
-      <source>Estonian</source>
-      <translation>Estoniano</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="531"/>
+        <source>Estonian</source>
+        <translation>Estoniano</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="533"/>
-      <source>Fijian</source>
-      <translation>Fijiano</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="533"/>
+        <source>Fijian</source>
+        <translation>Fijiano</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="535"/>
-      <source>Filipino</source>
-      <translation>Filipino</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="535"/>
+        <source>Filipino</source>
+        <translation>Filipino</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="537"/>
-      <source>Finnish</source>
-      <translation>Finlandês</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="537"/>
+        <source>Finnish</source>
+        <translation>Finlandês</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="539"/>
-      <source>French</source>
-      <translation>Francês</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="539"/>
+        <source>French</source>
+        <translation>Francês</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="541"/>
-      <source>Frisian</source>
-      <translation>Frísio</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="541"/>
+        <source>Frisian</source>
+        <translation>Frísio</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="543"/>
-      <source>Galician</source>
-      <translation>Galego</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="543"/>
+        <source>Galician</source>
+        <translation>Galego</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="545"/>
-      <source>Georgian</source>
-      <translation>Georgiano</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="545"/>
+        <source>Georgian</source>
+        <translation>Georgiano</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="547"/>
-      <source>German</source>
-      <translation>Alemão</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="547"/>
+        <source>German</source>
+        <translation>Alemão</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="549"/>
-      <source>Greek</source>
-      <translation>Grego</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="549"/>
+        <source>Greek</source>
+        <translation>Grego</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="551"/>
-      <source>Gujarati</source>
-      <translation>Guzerate</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="551"/>
+        <source>Gujarati</source>
+        <translation>Guzerate</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="553"/>
-      <source>Haitian Creole</source>
-      <translation>Crioulo haitiano</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="553"/>
+        <source>Haitian Creole</source>
+        <translation>Crioulo haitiano</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="555"/>
-      <source>Hausa</source>
-      <translation>Hauçá</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="555"/>
+        <source>Hausa</source>
+        <translation>Hauçá</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="557"/>
-      <source>Hawaiian</source>
-      <translation>Havaiano</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="557"/>
+        <source>Hawaiian</source>
+        <translation>Havaiano</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="559"/>
-      <source>Hebrew</source>
-      <translation>Hebraico</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="559"/>
+        <source>Hebrew</source>
+        <translation>Hebraico</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="561"/>
-      <source>Hill Mari</source>
-      <translation>Hill Mari</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="561"/>
+        <source>Hill Mari</source>
+        <translation>Hill Mari</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="563"/>
-      <source>Hindi</source>
-      <translation>Hindu</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="563"/>
+        <source>Hindi</source>
+        <translation>Hindu</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="565"/>
-      <source>Hmong</source>
-      <translation>Hmong</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="565"/>
+        <source>Hmong</source>
+        <translation>Hmong</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="567"/>
-      <source>Hungarian</source>
-      <translation>Húngaro</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="567"/>
+        <source>Hungarian</source>
+        <translation>Húngaro</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="569"/>
-      <source>Icelandic</source>
-      <translation>Islandês</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="569"/>
+        <source>Icelandic</source>
+        <translation>Islandês</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="571"/>
-      <source>Igbo</source>
-      <translation>Igbo</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="571"/>
+        <source>Igbo</source>
+        <translation>Igbo</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="573"/>
-      <source>Indonesian</source>
-      <translation>Indonésio</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="573"/>
+        <source>Indonesian</source>
+        <translation>Indonésio</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="575"/>
-      <source>Irish</source>
-      <translation>Irlandês</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="575"/>
+        <source>Irish</source>
+        <translation>Irlandês</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="577"/>
-      <source>Italian</source>
-      <translation>Italiano</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="577"/>
+        <source>Italian</source>
+        <translation>Italiano</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="579"/>
-      <source>Japanese</source>
-      <translation>Japonês</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="579"/>
+        <source>Japanese</source>
+        <translation>Japonês</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="581"/>
-      <source>Javanese</source>
-      <translation>Javanês</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="581"/>
+        <source>Javanese</source>
+        <translation>Javanês</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="583"/>
-      <source>Kannada</source>
-      <translation>Canarês</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="583"/>
+        <source>Kannada</source>
+        <translation>Canarês</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="585"/>
-      <source>Kazakh</source>
-      <translation>Cazaque</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="585"/>
+        <source>Kazakh</source>
+        <translation>Cazaque</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="587"/>
-      <source>Khmer</source>
-      <translation>Khmer</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="587"/>
+        <source>Khmer</source>
+        <translation>Khmer</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="589"/>
-      <source>Kinyarwanda</source>
-      <translation>Kinyarwanda</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="589"/>
+        <source>Kinyarwanda</source>
+        <translation>Kinyarwanda</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="591"/>
-      <source>Klingon</source>
-      <translation>Klingon</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="591"/>
+        <source>Klingon</source>
+        <translation>Klingon</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="593"/>
-      <source>Klingon (PlqaD)</source>
-      <translation>Klingon (PlqaD)</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="593"/>
+        <source>Klingon (PlqaD)</source>
+        <translation>Klingon (PlqaD)</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="595"/>
-      <source>Korean</source>
-      <translation>Coreano</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="595"/>
+        <source>Korean</source>
+        <translation>Coreano</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="597"/>
-      <source>Kurdish</source>
-      <translation>Curdo</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="597"/>
+        <source>Kurdish</source>
+        <translation>Curdo</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="599"/>
-      <source>Kyrgyz</source>
-      <translation>Quirguiz</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="599"/>
+        <source>Kyrgyz</source>
+        <translation>Quirguiz</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="601"/>
-      <source>Lao</source>
-      <translation>Laosiano</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="601"/>
+        <source>Lao</source>
+        <translation>Laosiano</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="603"/>
-      <source>Latin</source>
-      <translation>Latim</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="603"/>
+        <source>Latin</source>
+        <translation>Latim</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="605"/>
-      <source>Latvian</source>
-      <translation>Letão</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="605"/>
+        <source>Latvian</source>
+        <translation>Letão</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="607"/>
-      <source>Levantine Arabic</source>
-      <translation>Árabe Levantino</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="607"/>
+        <source>Levantine Arabic</source>
+        <translation>Árabe Levantino</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="609"/>
-      <source>Lithuanian</source>
-      <translation>Lituano</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="609"/>
+        <source>Lithuanian</source>
+        <translation>Lituano</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="611"/>
-      <source>Luxembourgish</source>
-      <translation>Luxemburguês</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="611"/>
+        <source>Luxembourgish</source>
+        <translation>Luxemburguês</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="613"/>
-      <source>Macedonian</source>
-      <translation>Macedônio</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="613"/>
+        <source>Macedonian</source>
+        <translation>Macedônio</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="615"/>
-      <source>Malagasy</source>
-      <translation>Malgaxe</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="615"/>
+        <source>Malagasy</source>
+        <translation>Malgaxe</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="617"/>
-      <source>Malay</source>
-      <translation>Malaio</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="617"/>
+        <source>Malay</source>
+        <translation>Malaio</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="619"/>
-      <source>Malayalam</source>
-      <translation>Malaiala</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="619"/>
+        <source>Malayalam</source>
+        <translation>Malaiala</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="621"/>
-      <source>Maltese</source>
-      <translation>Maltês</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="621"/>
+        <source>Maltese</source>
+        <translation>Maltês</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="623"/>
-      <source>Maori</source>
-      <translation>Maori</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="623"/>
+        <source>Maori</source>
+        <translation>Maori</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="625"/>
-      <source>Marathi</source>
-      <translation>Marata</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="625"/>
+        <source>Marathi</source>
+        <translation>Marata</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="627"/>
-      <source>Mari</source>
-      <translation>Mari</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="627"/>
+        <source>Mari</source>
+        <translation>Mari</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="629"/>
-      <source>Mongolian</source>
-      <translation>Mongol</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="629"/>
+        <source>Mongolian</source>
+        <translation>Mongol</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="631"/>
-      <source>Myanmar</source>
-      <translation>Birmanês</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="631"/>
+        <source>Myanmar</source>
+        <translation>Birmanês</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="633"/>
-      <source>Nepali</source>
-      <translation>Nepalês</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="633"/>
+        <source>Nepali</source>
+        <translation>Nepalês</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="635"/>
-      <source>Norwegian</source>
-      <translation>Norueguês</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="635"/>
+        <source>Norwegian</source>
+        <translation>Norueguês</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="637"/>
-      <source>Oriya</source>
-      <translation>Oriya</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="637"/>
+        <source>Oriya</source>
+        <translation>Oriya</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="639"/>
-      <source>Chichewa</source>
-      <translation>Chicheua</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="639"/>
+        <source>Chichewa</source>
+        <translation>Chicheua</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="641"/>
-      <source>Papiamento</source>
-      <translation>Papiamento</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="641"/>
+        <source>Papiamento</source>
+        <translation>Papiamento</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="643"/>
-      <source>Pashto</source>
-      <translation>Pachto</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="643"/>
+        <source>Pashto</source>
+        <translation>Pachto</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="645"/>
-      <source>Persian</source>
-      <translation>Persa</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="645"/>
+        <source>Persian</source>
+        <translation>Persa</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="647"/>
-      <source>Polish</source>
-      <translation>Polonês</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="647"/>
+        <source>Polish</source>
+        <translation>Polonês</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="649"/>
-      <source>Portuguese</source>
-      <translation>Português</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="649"/>
+        <source>Portuguese</source>
+        <translation>Português</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="651"/>
-      <source>Punjabi</source>
-      <translation>Punjabi</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="651"/>
+        <source>Punjabi</source>
+        <translation>Punjabi</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="653"/>
-      <source>Queretaro Otomi</source>
-      <translation>Otomi</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="653"/>
+        <source>Queretaro Otomi</source>
+        <translation>Otomi</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="655"/>
-      <source>Romanian</source>
-      <translation>Romeno</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="655"/>
+        <source>Romanian</source>
+        <translation>Romeno</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="657"/>
-      <source>Russian</source>
-      <translation>Russo</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="657"/>
+        <source>Russian</source>
+        <translation>Russo</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="659"/>
-      <source>Samoan</source>
-      <translation>Samoano</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="659"/>
+        <source>Samoan</source>
+        <translation>Samoano</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="661"/>
-      <source>Scots Gaelic</source>
-      <translation>Gaélico Escocês</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="661"/>
+        <source>Scots Gaelic</source>
+        <translation>Gaélico Escocês</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="663"/>
-      <source>Serbian (Cyrillic)</source>
-      <translation>Sérvio (Cirílico)</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="663"/>
+        <source>Serbian (Cyrillic)</source>
+        <translation>Sérvio (Cirílico)</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="665"/>
-      <source>Serbian (Latin)</source>
-      <translation>Sérvio (Latim)</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="665"/>
+        <source>Serbian (Latin)</source>
+        <translation>Sérvio (Latim)</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="667"/>
-      <source>Sesotho</source>
-      <translation>Sesoto</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="667"/>
+        <source>Sesotho</source>
+        <translation>Sesoto</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="669"/>
-      <source>Shona</source>
-      <translation>Xona</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="669"/>
+        <source>Shona</source>
+        <translation>Xona</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="671"/>
-      <source>Sindhi</source>
-      <translation>Sindi</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="671"/>
+        <source>Sindhi</source>
+        <translation>Sindi</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="673"/>
-      <source>Sinhala</source>
-      <translation>Cingalês</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="673"/>
+        <source>Sinhala</source>
+        <translation>Cingalês</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="675"/>
-      <source>Slovak</source>
-      <translation>Eslovaco</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="675"/>
+        <source>Slovak</source>
+        <translation>Eslovaco</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="677"/>
-      <source>Slovenian</source>
-      <translation>Esloveno</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="677"/>
+        <source>Slovenian</source>
+        <translation>Esloveno</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="679"/>
-      <source>Somali</source>
-      <translation>Somali</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="679"/>
+        <source>Somali</source>
+        <translation>Somali</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="681"/>
-      <source>Spanish</source>
-      <translation>Espanhol</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="681"/>
+        <source>Spanish</source>
+        <translation>Espanhol</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="683"/>
-      <source>Sundanese</source>
-      <translation>Sundanês</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="683"/>
+        <source>Sundanese</source>
+        <translation>Sundanês</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="685"/>
-      <source>Swahili</source>
-      <translation>Suaíle</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="685"/>
+        <source>Swahili</source>
+        <translation>Suaíle</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="687"/>
-      <source>Swedish</source>
-      <translation>Sueco</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="687"/>
+        <source>Swedish</source>
+        <translation>Sueco</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="689"/>
-      <source>Tagalog</source>
-      <translation>Tagalo</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="689"/>
+        <source>Tagalog</source>
+        <translation>Tagalo</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="691"/>
-      <source>Tahitian</source>
-      <translation>Taitiano</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="691"/>
+        <source>Tahitian</source>
+        <translation>Taitiano</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="693"/>
-      <source>Tajik</source>
-      <translation>Tadjique</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="693"/>
+        <source>Tajik</source>
+        <translation>Tadjique</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="695"/>
-      <source>Tamil</source>
-      <translation>Tâmil</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="695"/>
+        <source>Tamil</source>
+        <translation>Tâmil</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="697"/>
-      <source>Tatar</source>
-      <translation>Tártaro</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="697"/>
+        <source>Tatar</source>
+        <translation>Tártaro</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="699"/>
-      <source>Telugu</source>
-      <translation>Telugo</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="699"/>
+        <source>Telugu</source>
+        <translation>Telugo</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="701"/>
-      <source>Thai</source>
-      <translation>Tailandês</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="701"/>
+        <source>Thai</source>
+        <translation>Tailandês</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="703"/>
-      <source>Tongan</source>
-      <translation>Tonganês</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="703"/>
+        <source>Tongan</source>
+        <translation>Tonganês</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="705"/>
-      <source>Turkish</source>
-      <translation>Turco</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="705"/>
+        <source>Turkish</source>
+        <translation>Turco</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="707"/>
-      <source>Turkmen</source>
-      <translation>Turcomano</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="707"/>
+        <source>Turkmen</source>
+        <translation>Turcomano</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="709"/>
-      <source>Udmurt</source>
-      <translation>Udmurte</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="709"/>
+        <source>Udmurt</source>
+        <translation>Udmurte</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="711"/>
-      <source>Uighur</source>
-      <translation>Uighur</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="711"/>
+        <source>Uighur</source>
+        <translation>Uighur</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="713"/>
-      <source>Ukrainian</source>
-      <translation>Ucraniano</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="713"/>
+        <source>Ukrainian</source>
+        <translation>Ucraniano</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="715"/>
-      <source>Urdu</source>
-      <translation>Urdu</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="715"/>
+        <source>Urdu</source>
+        <translation>Urdu</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="717"/>
-      <source>Uzbek</source>
-      <translation>Uzbeque</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="717"/>
+        <source>Uzbek</source>
+        <translation>Uzbeque</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="719"/>
-      <source>Vietnamese</source>
-      <translation>Vietnamita</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="719"/>
+        <source>Vietnamese</source>
+        <translation>Vietnamita</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="721"/>
-      <source>Welsh</source>
-      <translation>Galês</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="721"/>
+        <source>Welsh</source>
+        <translation>Galês</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="723"/>
-      <source>Xhosa</source>
-      <translation>Xhosa</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="723"/>
+        <source>Xhosa</source>
+        <translation>Xhosa</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="725"/>
-      <source>Yiddish</source>
-      <translation>Iídiche</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="725"/>
+        <source>Yiddish</source>
+        <translation>Iídiche</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="727"/>
-      <source>Yoruba</source>
-      <translation>Ioruba</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="727"/>
+        <source>Yoruba</source>
+        <translation>Ioruba</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="729"/>
-      <source>Yucatec Maya</source>
-      <translation>Iucateque</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="729"/>
+        <source>Yucatec Maya</source>
+        <translation>Iucateque</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="731"/>
-      <source>Zulu</source>
-      <translation>Zulu</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="731"/>
+        <source>Zulu</source>
+        <translation>Zulu</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1250"/>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1259"/>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1342"/>
-      <source>Error: Engine systems have detected suspicious traffic from your computer network. Please try your request again later.</source>
-      <translation>Erro: Os mecanismo de tradução detectaram tráfego suspeito na rede da sua máquina. Tente novamente mais tarde.</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1250"/>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1259"/>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1342"/>
+        <source>Error: Engine systems have detected suspicious traffic from your computer network. Please try your request again later.</source>
+        <translation>Erro: Os motores de tradução detetaram tráfego suspeito na sua rede informática. Por favor tente novamente mais tarde.</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1271"/>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1422"/>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1615"/>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1709"/>
-      <source>Error: Unable to parse autodetected language</source>
-      <translation>Erro: Não foi possível interpretar o idioma detectado automaticamente</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1271"/>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1422"/>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1615"/>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1709"/>
+        <source>Error: Unable to parse autodetected language</source>
+        <translation>Erro: Não foi possível interpretar o idioma detetado automaticamente</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1349"/>
-      <source>Error: Unable to find Yandex SID in web version.</source>
-      <translation>Erro: Não foi possível encontrar o Yandex SID na versão web.</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1349"/>
+        <source>Error: Unable to find Yandex SID in web version.</source>
+        <translation>Erro: Não foi possível encontrar o Yandex SID na versão web.</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1356"/>
-      <source>Error: Unable to extract Yandex SID from web version.</source>
-      <translation>Erro: Não foi possível extrair o Yandex SID da versão web.</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1356"/>
+        <source>Error: Unable to extract Yandex SID from web version.</source>
+        <translation>Erro: Não foi possível extrair o Yandex SID da versão web.</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1536"/>
-      <source>Error: Unable to find Bing credentials in web version.</source>
-      <translation>Erro: Não foi possível encontrar credenciais do Bing na versão web.</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1536"/>
+        <source>Error: Unable to find Bing credentials in web version.</source>
+        <translation>Erro: Não foi possível encontrar credenciais do Bing na versão web.</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1543"/>
-      <source>Error: Unable to extract Bing key from web version.</source>
-      <translation>Erro: Não foi possível extrair a chave do Bing da versão web.</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1543"/>
+        <source>Error: Unable to extract Bing key from web version.</source>
+        <translation>Erro: Não foi possível extrair a chave do Bing da versão web.</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1551"/>
-      <source>Error: Unable to extract Bing token from web version.</source>
-      <translation>Erro: Não foi possível extrair o token do Bing da versão web.</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1551"/>
+        <source>Error: Unable to extract Bing token from web version.</source>
+        <translation>Erro: Não foi possível extrair o token do Bing da versão web.</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1559"/>
-      <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1567"/>
-      <source>Error: Unable to extract additional Bing information from web version.</source>
-      <translation>Erro: Não foi possível extrair informações adicionais do Bing da versão web.</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1559"/>
+        <location filename="../../src/qonlinetranslator/src/qonlinetranslator.cpp" line="1567"/>
+        <source>Error: Unable to extract additional Bing information from web version.</source>
+        <translation>Erro: Não foi possível extrair informações adicionais do Bing da versão web.</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>QOnlineTts</name>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetts.cpp" line="51"/>
-      <source>Selected engine %1 does not support voice settings</source>
-      <translation>O mecanismo selecionado %1 não suporta configurações de voz</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetts.cpp" line="51"/>
+        <source>Selected engine %1 does not support voice settings</source>
+        <translation>O motor selecionado %1 não suporta configurações de voz</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetts.cpp" line="56"/>
-      <source>Selected engine %1 does not support emotion settings</source>
-      <translation>O mecanismo selecionado %1 não suporta configurações de emoção</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetts.cpp" line="56"/>
+        <source>Selected engine %1 does not support emotion settings</source>
+        <translation>O motor selecionado %1 não suporta configurações de emoção</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetts.cpp" line="125"/>
-      <source>%1 engine does not support TTS</source>
-      <translation>O mecanismo %1 não suporta TTS</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetts.cpp" line="125"/>
+        <source>%1 engine does not support TTS</source>
+        <translation>O motor %1 não suporta TTS</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetts.cpp" line="196"/>
-      <source>Selected language %1 is not supported for %2</source>
-      <translation>O idioma selecionado %1 não é suportado para %2</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetts.cpp" line="196"/>
+        <source>Selected language %1 is not supported for %2</source>
+        <translation>O idioma selecionado %1 não é suportado para %2</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetts.cpp" line="208"/>
-      <source>Selected voice %1 is not supported for %2</source>
-      <translation>A voz selecionada %1 não é suportada para %2</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetts.cpp" line="208"/>
+        <source>Selected voice %1 is not supported for %2</source>
+        <translation>A voz selecionada %1 não é suportada para %2</translation>
     </message>
     <message>
-      <location filename="../../src/qonlinetranslator/src/qonlinetts.cpp" line="220"/>
-      <source>Selected emotion %1 is not supported for %2</source>
-      <translation>A emoção selecionada %1 não é suportada para %2</translation>
+        <location filename="../../src/qonlinetranslator/src/qonlinetts.cpp" line="220"/>
+        <source>Selected emotion %1 is not supported for %2</source>
+        <translation>A emoção selecionada %1 não é suportada para %2</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>SettingsDialog</name>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="14"/>
-      <source>Settings</source>
-      <translation>Configurações</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="14"/>
+        <source>Settings</source>
+        <translation>Definições</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="49"/>
-      <location filename="../../src/settings/settingsdialog.ui" line="144"/>
-      <source>General</source>
-      <translation>Geral</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="49"/>
+        <location filename="../../src/settings/settingsdialog.ui" line="144"/>
+        <source>General</source>
+        <translation>Geral</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="58"/>
-      <source>Interface</source>
-      <translation>Interface</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="58"/>
+        <source>Interface</source>
+        <translation>Interface</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="67"/>
-      <location filename="../../src/settings/settingsdialog.ui" line="651"/>
-      <source>Translation</source>
-      <translation>Tradução</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="67"/>
+        <location filename="../../src/settings/settingsdialog.ui" line="651"/>
+        <source>Translation</source>
+        <translation>Tradução</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="85"/>
-      <source>Speech synthesis</source>
-      <translation>Síntese de fala</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="85"/>
+        <source>Speech synthesis</source>
+        <translation>Síntese de fala</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="94"/>
-      <source>Connection</source>
-      <translation>Conexão</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="94"/>
+        <source>Connection</source>
+        <translation>Conexão</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="103"/>
-      <source>Shortcuts</source>
-      <translation>Atalhos</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="103"/>
+        <source>Shortcuts</source>
+        <translation>Atalhos</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="112"/>
-      <source>About</source>
-      <translation>Sobre</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="112"/>
+        <source>About</source>
+        <translation>Sobre</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="210"/>
-      <location filename="../../src/settings/settingsdialog.ui" line="359"/>
-      <source>Pop-up window</source>
-      <translation>Janela pop-up</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="210"/>
+        <location filename="../../src/settings/settingsdialog.ui" line="359"/>
+        <source>Pop-up window</source>
+        <translation>Janela pop-up</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="215"/>
-      <source>Main window</source>
-      <translation>Janela principal</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="215"/>
+        <source>Main window</source>
+        <translation>Janela principal</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="156"/>
-      <source>Language:</source>
-      <translation>Idioma:</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="156"/>
+        <source>Language:</source>
+        <translation>Idioma:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.cpp" line="72"/>
-      <location filename="../../src/settings/settingsdialog.cpp" line="94"/>
-      <location filename="../../src/settings/settingsdialog.cpp" line="95"/>
-      <source>&lt;System language&gt;</source>
-      <translation>&lt;Idioma do Sistema&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.cpp" line="72"/>
+        <location filename="../../src/settings/settingsdialog.cpp" line="94"/>
+        <location filename="../../src/settings/settingsdialog.cpp" line="95"/>
+        <source>&lt;System language&gt;</source>
+        <translation>&lt;System language&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="260"/>
-      <source>Show tray icon</source>
-      <translation>Mostrar ícone na bandeja</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="260"/>
+        <source>Show tray icon</source>
+        <translation>Mostrar ícone na bandeja</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="273"/>
-      <source>Start minimized</source>
-      <translation>Minimizar na inicialização</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="273"/>
+        <source>Start minimized</source>
+        <translation>Iniciar minimizado</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="199"/>
-      <source>Translation mode:</source>
-      <translation>Modo de tradução:</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="199"/>
+        <source>Translation mode:</source>
+        <translation>Modo de tradução:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="206"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A window for translating selected text. If the application is minimized, the main window will always be used.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Uma janela para traduzir o texto selecionado. Se a aplicação estiver minimizada, a janela principal sempre será usada.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="206"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A window for translating selected text. If the application is minimized, the main window will always be used.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Uma janela para traduzir o texto selecionado. Se a aplicação estiver minimizada, a janela principal sempre será usada.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="280"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Run the application at system startup&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Executar o aplicativo na inicialização do sistema&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="280"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Run the application at system startup&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Executar a aplicação na inicialização do sistema&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="283"/>
-      <source>Launch at startup</source>
-      <translation>Executar na inicialização</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="283"/>
+        <source>Launch at startup</source>
+        <translation>Executar na inicialização</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="270"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Start application minimized to the system tray&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Iniciar o aplicativo minimizado na bandeja do sistema&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="270"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Start application minimized to the system tray&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Iniciar a aplicação minimizada na bandeja do sistema&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="419"/>
-      <source>Opacity:</source>
-      <translation>Opacidade:</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="419"/>
+        <source>Opacity:</source>
+        <translation>Opacidade:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="392"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Pop-up window opacity&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Opacidade da janela pop-up&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="392"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Pop-up window opacity&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Opacidade da janela pop-up&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="329"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Translation and source text font&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Fonte da tradução e texto de origem&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="329"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Translation and source text font&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Fonte da tradução e texto de origem&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="343"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Font size of translation and source text&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tamanho da fonte da tradução e do texto fonte&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="343"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Font size of translation and source text&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tamanho da fonte da tradução e do texto fonte&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="433"/>
-      <source>Height:</source>
-      <translation>Altura:</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="433"/>
+        <source>Height:</source>
+        <translation>Altura:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="365"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Pop-up window height in pixels&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Altura da janela pop-up em pixels&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="365"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Pop-up window height in pixels&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Altura da janela pop-up em pixels&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="375"/>
-      <source>Width:</source>
-      <translation>Largura:</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="375"/>
+        <source>Width:</source>
+        <translation>Largura:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="382"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Pop-up window width in pixels&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Largura da janela pop-up em pixels&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="382"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Pop-up window width in pixels&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Largura da janela pop-up em pixels&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="228"/>
-      <source>Translation notification timeout:</source>
-      <translation>Tempo de notificação da tradução:</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="228"/>
+        <source>Translation notification timeout:</source>
+        <translation>Tempo de notificação da tradução:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="241"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Notification with translation display time&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Notificação com o tempo de exibição da tradução&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="241"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Notification with translation display time&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Notificação com o tempo de exibição da tradução&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="244"/>
-      <location filename="../../src/settings/settingsdialog.ui" line="449"/>
-      <source> sec</source>
-      <translation> seg.</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="244"/>
+        <location filename="../../src/settings/settingsdialog.ui" line="449"/>
+        <source> sec</source>
+        <translation> seg</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="482"/>
-      <location filename="../../src/settings/settingsdialog.ui" line="506"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Languages text on buttons&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Texto de idiomas nos botões&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="482"/>
+        <location filename="../../src/settings/settingsdialog.ui" line="506"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Languages text on buttons&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Texto de idiomas nos botões&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="526"/>
-      <source>Tray icon</source>
-      <translation>Ícone da bandeja</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="526"/>
+        <source>Tray icon</source>
+        <translation>Ícone da bandeja</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="532"/>
-      <source>Icon:</source>
-      <translation>Ícone:</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="532"/>
+        <source>Icon:</source>
+        <translation>Ícone:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="613"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select icon&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Selecionar ícone&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="613"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select icon&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Selecionar ícone&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="545"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;System tray icon&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ícone da bandeja do sistema&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="545"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;System tray icon&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ícone da bandeja do sistema&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="549"/>
-      <source>Default</source>
-      <translation>Padrão</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="549"/>
+        <source>Default</source>
+        <translation>Padrão</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="558"/>
-      <source>Monochrome (dark theme)</source>
-      <translation>Monocromático (tema escuro)</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="558"/>
+        <source>Monochrome (dark theme)</source>
+        <translation>Monocromático (tema escuro)</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="567"/>
-      <source>Monochrome (light theme)</source>
-      <translation>Monocromático (tema claro)</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="567"/>
+        <source>Monochrome (light theme)</source>
+        <translation>Monocromático (tema claro)</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="576"/>
-      <source>Custom</source>
-      <translation>Personalizado</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="576"/>
+        <source>Custom</source>
+        <translation>Personalizado</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="591"/>
-      <source>Custom:</source>
-      <translation>Personalizado:</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="591"/>
+        <source>Custom:</source>
+        <translation>Personalizado:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1197"/>
-      <source>Zahar</source>
-      <translation>Zahar</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1197"/>
+        <source>Zahar</source>
+        <translation>Zahar</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1202"/>
-      <source>Ermil</source>
-      <translation>Ermil</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1202"/>
+        <source>Ermil</source>
+        <translation>Ermil</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1207"/>
-      <source>Jane</source>
-      <translation>Jane</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1207"/>
+        <source>Jane</source>
+        <translation>Jane</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1212"/>
-      <source>Oksana</source>
-      <translation>Oksana</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1212"/>
+        <source>Oksana</source>
+        <translation>Oksana</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1217"/>
-      <source>Alyss</source>
-      <translation>Alyss</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1217"/>
+        <source>Alyss</source>
+        <translation>Alyss</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1222"/>
-      <source>Omazh</source>
-      <translation>Omazh</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1222"/>
+        <source>Omazh</source>
+        <translation>Omazh</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1230"/>
-      <source>Emotional connotation:</source>
-      <translation>Conotação emocional:</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1230"/>
+        <source>Emotional connotation:</source>
+        <translation>Conotação emocional:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1247"/>
-      <source>Neutral</source>
-      <translation>Neutro</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1247"/>
+        <source>Neutral</source>
+        <translation>Neutro</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1252"/>
-      <source>Good</source>
-      <translation>Bom</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1252"/>
+        <source>Good</source>
+        <translation>Bom</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1257"/>
-      <source>Evil</source>
-      <translation>Mau</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1257"/>
+        <source>Evil</source>
+        <translation>Mau</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="660"/>
-      <source>Enable source transliteration</source>
-      <translation>Habilitar transliteração da origem</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="660"/>
+        <source>Enable source transliteration</source>
+        <translation>Ativar transliteração da origem</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="670"/>
-      <source>Enable translation transliteration</source>
-      <translation>Habilitar transliteração de tradução</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="670"/>
+        <source>Enable translation transliteration</source>
+        <translation>Ativar transliteração de tradução</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="680"/>
-      <source>Enable source transcription</source>
-      <translation>Habilitar transcrição da fonte</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="680"/>
+        <source>Enable source transcription</source>
+        <translation>Ativar transcrição da fonte</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="690"/>
-      <source>Enable translation options</source>
-      <translation>Habilitar opções de tradução</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="690"/>
+        <source>Enable translation options</source>
+        <translation>Ativar opções de tradução</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="697"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable or disable usage examples&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Habilitar ou desativar os exemplos de utilização&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="697"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable or disable usage examples&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ativar ou desativar exemplos de uso&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="700"/>
-      <source>Enable examples</source>
-      <translation>Habilitar exemplos</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="700"/>
+        <source>Enable examples</source>
+        <translation>Ativar exemplos</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="720"/>
-      <source>Automatic language detection</source>
-      <translation>Detecção automática de idioma</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="720"/>
+        <source>Automatic language detection</source>
+        <translation>Deteção automática de idioma</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="726"/>
-      <source>Primary translation language:</source>
-      <translation>Idioma de tradução principal:</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="726"/>
+        <source>Primary translation language:</source>
+        <translation>Idioma de tradução principal:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="740"/>
-      <source>Secondary translation language:</source>
-      <translation>Idioma de tradução secundário:</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="740"/>
+        <source>Secondary translation language:</source>
+        <translation>Idioma de tradução secundário:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="747"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Language to which the text will be translated if it is in the language selected above&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Idioma para o qual o texto será traduzido se estiver no idioma selecionado acima&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="747"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Language to which the text will be translated if it is in the language selected above&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Idioma para o qual o texto será traduzido se estiver no idioma selecionado acima&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="969"/>
-      <source>Directory with trained models</source>
-      <translation>Pasta com modelos treinados</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="969"/>
+        <source>Directory with trained models</source>
+        <translation>Pasta com modelos treinados</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="938"/>
-      <source>Languages path:</source>
-      <translation>Caminho do idioma:</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="938"/>
+        <source>Languages path:</source>
+        <translation>Caminho do idioma:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="945"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select OCR languages path&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Selecione o caminho dos idiomas OCR&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="945"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select OCR languages path&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Selecione o caminho dos idiomas OCR&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="931"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Loading additional languages will impact both speed and accuracy, as there is more work to do to decide on the applicable language, and there is more chance of hallucinating incorrect words.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Carregar idiomas adicionais terá um impacto na velocidade e precisão, à medida que há mais trabalho a fazer para decidir sobre o idioma aplicável, e há mais possibilidade de surgirem palavras incorretas.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="931"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Loading additional languages will impact both speed and accuracy, as there is more work to do to decide on the applicable language, and there is more chance of hallucinating incorrect words.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Carregar idiomas adicionais terá um impacto na velocidade e precisão, pois há mais trabalho a fazer para decidir sobre o idioma aplicável, e há mais possibilidade de surgirem palavras incorretas.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="956"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open GitHub repository&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Abrir repositório no GitHub&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="956"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open GitHub repository&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Abrir repositório do GitHub&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="959"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/tesseract-ocr/tessdata&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;Download more&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/tesseract-ocr/tessdata&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;Baixar mais&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="959"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/tesseract-ocr/tessdata&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;Download more&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/tesseract-ocr/tessdata&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;Transferir mais&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1054"/>
-      <source>Screen capture</source>
-      <translation>Capturar tela</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1054"/>
+        <source>Screen capture</source>
+        <translation>Capturar ecrã</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1066"/>
-      <source>Remember region:</source>
-      <translation>Lembrar região:</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1066"/>
+        <source>Remember region:</source>
+        <translation>Lembrar região:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1115"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show a magnifier next to the cursor&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar uma lupa próximo ao cursor&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1115"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show a magnifier next to the cursor&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar uma lupa ao lado do cursor&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1118"/>
-      <source>Show magnifier</source>
-      <translation>Mostrar lupa</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1118"/>
+        <source>Show magnifier</source>
+        <translation>Mostrar lupa</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1138"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply a slight fog to the unselected part&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Aplicar um pequeno desfoque na parte não selecionada&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1138"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply a slight fog to the unselected part&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Aplicar um pequeno desfoque na parte não selecionada&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1141"/>
-      <source>Apply light mask</source>
-      <translation>Aplicar máscara de luz</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1141"/>
+        <source>Apply light mask</source>
+        <translation>Aplicar máscara de luz</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1082"/>
-      <source>Remember last</source>
-      <translation>Lembrar última</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1082"/>
+        <source>Remember last</source>
+        <translation>Lembrar última</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="426"/>
-      <source>Show timeout:</source>
-      <translation>Mostrar tempo limite:</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="426"/>
+        <source>Show timeout:</source>
+        <translation>Mostrar tempo limite:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="446"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The number of seconds after which the window will be hidden if it has no focus&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;O número de segundos após os quais a janela ficará oculta se não tiver foco&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="446"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The number of seconds after which the window will be hidden if it has no focus&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;O número de segundos após os quais a janela ficará oculta se não tiver foco&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="816"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;LibreTranslate engine URL&lt;/p&gt;&lt;p&gt;All instances can be found here: https://github.com/LibreTranslate/LibreTranslate#mirrors&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;URL do mecanismo LibreTranslate&lt;/p&gt;&lt;p&gt;Todas as instâncias podem ser encontradas aqui: https://github.com/LibreTranslate/LibreTranslate#mirrors&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="816"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;LibreTranslate engine URL&lt;/p&gt;&lt;p&gt;All instances can be found here: https://github.com/LibreTranslate/LibreTranslate#mirrors&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;URL do motor LibreTranslate&lt;/p&gt;&lt;p&gt;Todas as instâncias podem ser encontradas aqui: https://github.com/LibreTranslate/LibreTranslate#mirrors&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="871"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Lingva engine URL&lt;/p&gt;&lt;p&gt;All instances can be found here: https://github.com/TheDavidDelta/lingva-translate#instances&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;URL do mecanismo Lingva&lt;/p&gt;&lt;p&gt;Todas as instâncias podem ser encontradas aqui: https://github.com/TheDavidDelta/lingva-translate#instances&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="871"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Lingva engine URL&lt;/p&gt;&lt;p&gt;All instances can be found here: https://github.com/TheDavidDelta/lingva-translate#instances&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;URL do motor Lingva&lt;/p&gt;&lt;p&gt;Todas as instâncias podem ser encontradas aqui: https://github.com/TheDavidDelta/lingva-translate#instances&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1087"/>
-      <source>Remember always</source>
-      <translation>Lembrar sempre</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1087"/>
+        <source>Remember always</source>
+        <translation>Lembrar sempre</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1128"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Finish capturing the fragment when the mouse button is released&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Termine de capturar o fragmento quando o botão do mouse for liberado&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1128"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Finish capturing the fragment when the mouse button is released&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Termine de capturar o fragmento quando o botão do mouse for solto&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1180"/>
-      <source>Voice:</source>
-      <translation>Voz:</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1180"/>
+        <source>Voice:</source>
+        <translation>Voz:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1243"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Voice mood of the speech synthesis engine&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Humor da voz do mecanismo de síntese de fala&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1243"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Voice mood of the speech synthesis engine&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sentimento da voz do motor de síntese de fala&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1265"/>
-      <source>Speech test:</source>
-      <translation>Teste de pronuncia:</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1265"/>
+        <source>Speech test:</source>
+        <translation>Teste de fala:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1277"/>
-      <source>This is an example of speech synthesis.</source>
-      <translation>Este é um exemplo de síntese de fala.</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1277"/>
+        <source>This is an example of speech synthesis.</source>
+        <translation>Este é um exemplo de síntese de fala.</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1280"/>
-      <source>Test voice</source>
-      <translation>Testar voz</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1280"/>
+        <source>Test voice</source>
+        <translation>Testar voz</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1318"/>
-      <source>Proxy server</source>
-      <translation>Servidor proxy</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1318"/>
+        <source>Proxy server</source>
+        <translation>Servidor proxy</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1324"/>
-      <source>Type:</source>
-      <translation>Tipo:</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1324"/>
+        <source>Type:</source>
+        <translation>Tipo:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1341"/>
-      <source>Use system settings</source>
-      <translation>Use as configurações do sistema</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1341"/>
+        <source>Use system settings</source>
+        <translation>Usar as definições do sistema</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1351"/>
-      <source>Don&apos;t use a proxy</source>
-      <translation>Não usar um proxy</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1351"/>
+        <source>Don&apos;t use a proxy</source>
+        <translation>Não usar um proxy</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1367"/>
-      <source>Host:</source>
-      <translation>Endereço:</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1367"/>
+        <source>Host:</source>
+        <translation>Anfitrião:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1390"/>
-      <source>Port:</source>
-      <translation>Porta:</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1390"/>
+        <source>Port:</source>
+        <translation>Porta:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1425"/>
-      <source>Info: the proxy works only for text translation</source>
-      <translation>Nota: As configurações de proxy são válidas apenas para tradução de texto</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1425"/>
+        <source>Info: the proxy works only for text translation</source>
+        <translation>Info: As configurações de proxy são válidas apenas para tradução de texto</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1435"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable or disable authentication&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ative ou desative a autenticação&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1435"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable or disable authentication&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ativar ou desativar autenticação&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1438"/>
-      <source>Authentication</source>
-      <translation>Autenticação</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1438"/>
+        <source>Authentication</source>
+        <translation>Autenticação</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1448"/>
-      <source>Username:</source>
-      <translation>Nome de usuário:</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1448"/>
+        <source>Username:</source>
+        <translation>Nome de utilizador:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1458"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Proxy username for authentication&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Nome de usuário do proxy para autenticação&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1458"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Proxy username for authentication&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Nome de utilizador do proxy para autenticação&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1468"/>
-      <source>Password:</source>
-      <translation>Senha:</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1468"/>
+        <source>Password:</source>
+        <translation>Senha:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="220"/>
-      <source>Notification</source>
-      <translation>Notificação</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="220"/>
+        <source>Notification</source>
+        <translation>Notificação</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="163"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Interface language&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Idioma da interface&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="163"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Interface language&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Idioma do interface&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="257"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Display icon in the system tray&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Exibir ícone na bandeja do sistema&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="257"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Display icon in the system tray&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar ícone na bandeja do sistema&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="170"/>
-      <source>Main window orientation:</source>
-      <translation>Orientação da janela principal:</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="170"/>
+        <source>Main window orientation:</source>
+        <translation>Orientação da janela principal:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="177"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Orientation of the main window layout&lt;br/&gt;When using &lt;span style=&quot; font-style:italic;&quot;&gt;Auto&lt;/span&gt;, the window orientation will match the screen orientation&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Orientação do layout da janela principal&lt;br/&gt;ao usar &lt;span style=&quot; font-style:italic;&quot;&gt;Automático&lt;/span&gt;, a orientação da janela corresponderá à orientação da tela&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="177"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Orientation of the main window layout&lt;br/&gt;When using &lt;span style=&quot; font-style:italic;&quot;&gt;Auto&lt;/span&gt;, the window orientation will match the screen orientation&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Orientação do layout da janela principal&lt;br/&gt;ao usar &lt;span style=&quot; font-style:italic;&quot;&gt;Auto&lt;/span&gt;, a orientação da janela corresponderá à orientação do ecrã&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="181"/>
-      <source>Auto</source>
-      <extracomment>Orientation</extracomment>
-      <translation>Automático</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="181"/>
+        <source>Auto</source>
+        <extracomment>Orientation</extracomment>
+        <translation>Auto</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="186"/>
-      <source>Portrait</source>
-      <extracomment>Orientation</extracomment>
-      <translation>Retrato</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="186"/>
+        <source>Portrait</source>
+        <extracomment>Orientation</extracomment>
+        <translation>Retrato</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="191"/>
-      <source>Landscape</source>
-      <extracomment>Orientation</extracomment>
-      <translation>Paisagem</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="191"/>
+        <source>Landscape</source>
+        <extracomment>Orientation</extracomment>
+        <translation>Paisagem</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="316"/>
-      <source>Font</source>
-      <translation>Fonte</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="316"/>
+        <source>Font</source>
+        <translation>Fonte</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="322"/>
-      <source>Name:</source>
-      <translation>Nome:</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="322"/>
+        <source>Name:</source>
+        <translation>Nome:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="336"/>
-      <source>Size:</source>
-      <translation>Tamanho:</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="336"/>
+        <source>Size:</source>
+        <translation>Tamanho:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="469"/>
-      <source>Language format</source>
-      <translation>Formato do idioma</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="469"/>
+        <source>Language format</source>
+        <translation>Formato do idioma</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="475"/>
-      <source>Main window:</source>
-      <translation>Janela principal:</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="475"/>
+        <source>Main window:</source>
+        <translation>Janela principal:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="486"/>
-      <location filename="../../src/settings/settingsdialog.ui" line="510"/>
-      <source>Full name</source>
-      <translation>Nome completo</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="486"/>
+        <location filename="../../src/settings/settingsdialog.ui" line="510"/>
+        <source>Full name</source>
+        <translation>Nome completo</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="491"/>
-      <location filename="../../src/settings/settingsdialog.ui" line="515"/>
-      <source>ISO 639-1 code</source>
-      <translation>Código ISO 639-1</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="491"/>
+        <location filename="../../src/settings/settingsdialog.ui" line="515"/>
+        <source>ISO 639-1 code</source>
+        <translation>Código ISO 639-1</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="499"/>
-      <source>Pop-up:</source>
-      <translation>Popup:</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="499"/>
+        <source>Pop-up:</source>
+        <translation>Popup:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="657"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable or disable source transliteration&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Habilitar ou desativar a transliteração da origem&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="657"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable or disable source transliteration&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ativar ou desativar transliteração da origem&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="667"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable or disable translation transliteration&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Habilitar ou desativar a transliteração de tradução&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="667"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable or disable translation transliteration&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ativarr ou desativar transliteração da tradução&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="677"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable or disable source transcription&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Habilitar ou desativar a transcrição da origem&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="677"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable or disable source transcription&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ativar ou desativar transcrição da origem&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="687"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable or disable translation options&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Habilitar ou desativar opções de tradução&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="687"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable or disable translation options&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ativar ou desativar opções de tradução&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="707"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Replace each sequence of whitespaces (this includes the ASCII characters &apos;\t&apos;, &apos;\n&apos;, &apos;\v&apos;, &apos;\f&apos;, &apos;\r&apos;, and &apos; &apos;) with a single space in queries&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Substitui cada sequência de espaços em branco (isto inclui os caracteres ASCII &apos;\t&apos;, &apos;\n&apos;, &apos;\v&apos;, &apos;\f&apos;, &apos;\r&apos;, e &apos; &apos;) com um único espaço nas consultas&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="707"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Replace each sequence of whitespaces (this includes the ASCII characters &apos;\t&apos;, &apos;\n&apos;, &apos;\v&apos;, &apos;\f&apos;, &apos;\r&apos;, and &apos; &apos;) with a single space in queries&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Substitui cada sequência de espaços em branco (isto inclui os caracteres ASCII &apos;\t&apos;, &apos;\n&apos;, &apos;\v&apos;, &apos;\f&apos;, &apos;\r&apos;, e &apos; &apos;) com um único espaço nas consultas&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="710"/>
-      <source>Simplify source</source>
-      <translation>Simplificar fonte</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="710"/>
+        <source>Simplify source</source>
+        <translation>Simplificar fonte</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="733"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Language to which text will be translated when autodetecting&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Idioma para o qual o texto será traduzido durante a autodetecção&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="733"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Language to which text will be translated when autodetecting&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Idioma para o qual o texto será traduzido durante a autodeteção&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="754"/>
-      <location filename="../../src/settings/settingsdialog.ui" line="764"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Automatically switch to &lt;span style=&quot; font-style:italic;&quot;&gt;Auto&lt;/span&gt; when using OCR and global shortcuts&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Automaticamente mudar para &lt;span style=&quot; font-style:italic;&quot;&gt;Automático&lt;/span&gt; quando usar atalhos globais e OCR&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="754"/>
+        <location filename="../../src/settings/settingsdialog.ui" line="764"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Automatically switch to &lt;span style=&quot; font-style:italic;&quot;&gt;Auto&lt;/span&gt; when using OCR and global shortcuts&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mudar automaticamente para &lt;span style=&quot; font-style:italic;&quot;&gt;Auto&lt;/span&gt; quando usar atalhos globais e OCR&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="757"/>
-      <source>Force source language detection</source>
-      <translation>Forçar detecção de idioma de origem</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="757"/>
+        <source>Force source language detection</source>
+        <translation>Forçar deteção de idioma de origem</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="767"/>
-      <source>Force translation language detection</source>
-      <translation>Forçar detecção do idioma de tradução</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="767"/>
+        <source>Force translation language detection</source>
+        <translation>Forçar deteção do idioma de tradução</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="790"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;LibreTranslate instance API key&lt;/p&gt;&lt;p&gt;Free instances listed here doesn&apos;t require a key, so field can be empty&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Chave API da instância do LibreTranslate&lt;/p&gt;&lt;p&gt;Instâncias grátis listadas aqui não necessitam de uma chave, assim o campo pode ficar vazio&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="790"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;LibreTranslate instance API key&lt;/p&gt;&lt;p&gt;Free instances listed here doesn&apos;t require a key, so field can be empty&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Chave API da instância do LibreTranslate&lt;/p&gt;&lt;p&gt;Instâncias grátis listadas aqui não necessitam de uma chave, assim o campo pode ficar vazio&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="803"/>
-      <source>API key:</source>
-      <translation>Chave API:</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="803"/>
+        <source>API key:</source>
+        <translation>Chave API:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="925"/>
-      <source>Languages</source>
-      <translation>Idiomas</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="925"/>
+        <source>Languages</source>
+        <translation>Idiomas</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="985"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Replace all single line breaks with a space after text recognition&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Substitua todas as quebras de linha simples por um espaço após reconhecimento de texto&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="985"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Replace all single line breaks with a space after text recognition&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Substitua todas as quebras de linha simples por um espaço após reconhecimento de texto&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="988"/>
-      <source>Convert line breaks</source>
-      <translation>Converter quebras de linha</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="988"/>
+        <source>Convert line breaks</source>
+        <translation>Converter quebras de linha</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1073"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When to remember the last selected region&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Quando lembrar a última região selecionada&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1073"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When to remember the last selected region&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Quando lembrar a última região selecionada&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1095"/>
-      <source>Capture delay:</source>
-      <translation>Atraso de captura:</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1095"/>
+        <source>Capture delay:</source>
+        <translation>Atraso de captura:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1102"/>
-      <source>Delay before screen capture</source>
-      <translation>Atraso antes da captura de tela</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1102"/>
+        <source>Delay before screen capture</source>
+        <translation>Atraso antes da captura de ecrã</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1105"/>
-      <source> ms</source>
-      <translation> ms</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1105"/>
+        <source> ms</source>
+        <translation> ms</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1131"/>
-      <source>Confirm on release</source>
-      <translation>Confirmar ao liberar</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1131"/>
+        <source>Confirm on release</source>
+        <translation>Confirmar ao soltar</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1193"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Voice of the speech synthesis engine&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Voz do mecanismo de síntese de fala&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1193"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Voice of the speech synthesis engine&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Voz do motor de síntese da fala&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1274"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Text to test speech&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Texto para testar a síntese de fala&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1274"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Text to test speech&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Texto para testar a síntese de fala&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1491"/>
-      <source>Info: the password is saved unencrypted</source>
-      <translation>Nota: a senha é salva sem criptografia</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1491"/>
+        <source>Info: the password is saved unencrypted</source>
+        <translation>Info: a senha é salva sem criptografia</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1406"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Proxy port&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Porta do proxy&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1406"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Proxy port&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Porta do proxy&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1377"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Proxy host name&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Nome do endereço de proxy&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1377"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Proxy host name&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Nome do anfitrião proxy&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1337"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Proxy type&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tipo de proxy&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1337"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Proxy type&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tipo de proxy&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1527"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Register global shortcuts in system&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Registrar atalhos globais no sistema&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1527"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Register global shortcuts in system&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Registar atalhos globais no sistema&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1530"/>
-      <source>Enable global shortcucts</source>
-      <translation>Ativar atalhos globais</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1530"/>
+        <source>Enable global shortcucts</source>
+        <translation>Ativar atalhos globais</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1559"/>
-      <source>Shortcut</source>
-      <translation>Atalho</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1559"/>
+        <source>Shortcut</source>
+        <translation>Atalho</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1549"/>
-      <source>Reset all</source>
-      <translation>Restaurar padrões</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1549"/>
+        <source>Reset all</source>
+        <translation>Redefinir tudo</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="603"/>
-      <source>Path to the icon or icon name from theme</source>
-      <translation>Caminho para o ícone ou nome do ícone do tema</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="603"/>
+        <source>Path to the icon or icon name from theme</source>
+        <translation>Caminho para o ícone ou nome do ícone do tema</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1478"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Proxy password for authentication&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Senha do proxy para autenticação&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1478"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Proxy password for authentication&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Senha do proxy para autenticação&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1565"/>
-      <source>Key sequence:</source>
-      <translation>Sequência de teclas:</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1565"/>
+        <source>Key sequence:</source>
+        <translation>Sequência de teclas:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1579"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Accept shortcut&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Aceitar atalho&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1579"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Accept shortcut&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Aceitar atalho&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1582"/>
-      <source>Accept</source>
-      <translation>Aceitar</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1582"/>
+        <source>Accept</source>
+        <translation>Aceitar</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1593"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Clear shortcut&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Limpar atalho&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1593"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Clear shortcut&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Limpar atalho&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1596"/>
-      <source>Clear</source>
-      <translation>Limpar</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1596"/>
+        <source>Clear</source>
+        <translation>Limpar</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1610"/>
-      <source>Reset</source>
-      <translation>Resetar</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1610"/>
+        <source>Reset</source>
+        <translation>Redefinir</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1656"/>
-      <source>Version:</source>
-      <translation>Versão:</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1656"/>
+        <source>Version:</source>
+        <translation>Versão:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1546"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Reset all shortcuts to defaults&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Restaurar todos os atalhos para o padrão&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1546"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Reset all shortcuts to defaults&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Restaurar todos os atalhos para os padrões&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1572"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The key sequence for the selected action&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A sequência de teclas para a ação selecionada&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1572"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The key sequence for the selected action&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A sequência de teclas para a ação selecionada&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1607"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Reset shortcut to default&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Restaurar atalho para o padrão&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1607"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Reset shortcut to default&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Restaurar atalho para o padrão&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1666"/>
-      <source>License:</source>
-      <translation>Licença:</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1666"/>
+        <source>License:</source>
+        <translation>Licença:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1680"/>
-      <source>Source code:</source>
-      <translation>Código fonte:</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1680"/>
+        <source>Source code:</source>
+        <translation>Código fonte:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1720"/>
-      <source>Flag icons:</source>
-      <translation>Ícones das bandeiras:</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1720"/>
+        <source>Flag icons:</source>
+        <translation>Ícones das bandeiras:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.cpp" line="50"/>
-      <source>Portable mode</source>
-      <translation>Modo portátil</translation>
+        <location filename="../../src/settings/settingsdialog.cpp" line="50"/>
+        <source>Portable mode</source>
+        <translation>Modo portátil</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.cpp" line="63"/>
-      <source>Use %1 from the application folder to store settings</source>
-      <translation>Use %1 da pasta do aplicativo para armazenar as configurações</translation>
+        <location filename="../../src/settings/settingsdialog.cpp" line="63"/>
+        <source>Use %1 from the application folder to store settings</source>
+        <translation>Usar %1 da pasta da aplicação para armazenar as configurações</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.cpp" line="137"/>
-      <source>Updates</source>
-      <translation>Atualizações</translation>
+        <location filename="../../src/settings/settingsdialog.cpp" line="137"/>
+        <source>Updates</source>
+        <translation>Atualizações</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.cpp" line="144"/>
-      <source>Check for updates:</source>
-      <translation>Verificar atualizações:</translation>
+        <location filename="../../src/settings/settingsdialog.cpp" line="144"/>
+        <source>Check for updates:</source>
+        <translation>Verificar atualizações:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.cpp" line="148"/>
-      <source>Every day</source>
-      <translation>Diariamente</translation>
+        <location filename="../../src/settings/settingsdialog.cpp" line="148"/>
+        <source>Every day</source>
+        <translation>Diariamente</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.cpp" line="149"/>
-      <source>Every week</source>
-      <translation>Semanalmente</translation>
+        <location filename="../../src/settings/settingsdialog.cpp" line="149"/>
+        <source>Every week</source>
+        <translation>Semanalmente</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.cpp" line="150"/>
-      <source>Every month</source>
-      <translation>Mensalmente</translation>
+        <location filename="../../src/settings/settingsdialog.cpp" line="150"/>
+        <source>Every month</source>
+        <translation>Mensalmente</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.ui" line="1077"/>
-      <location filename="../../src/settings/settingsdialog.cpp" line="151"/>
-      <source>Never</source>
-      <translation>Nunca</translation>
+        <location filename="../../src/settings/settingsdialog.ui" line="1077"/>
+        <location filename="../../src/settings/settingsdialog.cpp" line="151"/>
+        <source>Never</source>
+        <translation>Nunca</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.cpp" line="127"/>
-      <source>Icons:</source>
-      <translation>Ícones:</translation>
+        <location filename="../../src/settings/settingsdialog.cpp" line="127"/>
+        <source>Icons:</source>
+        <translation>Ícones:</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.cpp" line="155"/>
-      <source>Check now</source>
-      <translation>Verificar agora</translation>
+        <location filename="../../src/settings/settingsdialog.cpp" line="155"/>
+        <source>Check now</source>
+        <translation>Verificar agora</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.cpp" line="156"/>
-      <source>Check for updates now</source>
-      <translation>Verificar atualizações agora</translation>
+        <location filename="../../src/settings/settingsdialog.cpp" line="156"/>
+        <source>Check for updates now</source>
+        <translation>Verificar atualizações agora</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.cpp" line="169"/>
-      <source>Happy New Year!</source>
-      <translation>Feliz Ano Novo!</translation>
+        <location filename="../../src/settings/settingsdialog.cpp" line="169"/>
+        <source>Happy New Year!</source>
+        <translation>Feliz Ano Novo!</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.cpp" line="183"/>
-      <source>The OCR parameter fields can not be empty.</source>
-      <translation>Os campos do parâmetro OCR não podem estar vazios.</translation>
+        <location filename="../../src/settings/settingsdialog.cpp" line="183"/>
+        <source>The OCR parameter fields can not be empty.</source>
+        <translation>Os campos do parâmetro OCR não podem estar vazios.</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.cpp" line="184"/>
-      <source>Do you want to discard the invalid parameters?</source>
-      <translation>Você quer descartar os parâmetros inválidos?</translation>
+        <location filename="../../src/settings/settingsdialog.cpp" line="184"/>
+        <source>Do you want to discard the invalid parameters?</source>
+        <translation>Quer descartar os parâmetros inválidos?</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.cpp" line="333"/>
-      <source>Select icon</source>
-      <translation>Selecione o ícone</translation>
+        <location filename="../../src/settings/settingsdialog.cpp" line="333"/>
+        <source>Select icon</source>
+        <translation>Selecione ícone</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.cpp" line="333"/>
-      <source>Images (*.png *.ico *.svg *.jpg);;All files()</source>
-      <translation>Imagens (*.png *.ico *.svg *.jpg);;Todos os arquivos()</translation>
+        <location filename="../../src/settings/settingsdialog.cpp" line="333"/>
+        <source>Images (*.png *.ico *.svg *.jpg);;All files()</source>
+        <translation>Imagens (*.png *.ico *.svg *.jpg);;Todos os ficheiros()</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.cpp" line="346"/>
-      <source>Select OCR languages path</source>
-      <translation>Selecione o caminho dos idiomas OCR</translation>
+        <location filename="../../src/settings/settingsdialog.cpp" line="346"/>
+        <source>Select OCR languages path</source>
+        <translation>Selecione o caminho dos idiomas OCR</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.cpp" line="381"/>
-      <source>Nothing to play</source>
-      <translation>Nada para reproduzir</translation>
+        <location filename="../../src/settings/settingsdialog.cpp" line="381"/>
+        <source>Nothing to play</source>
+        <translation>Nada para reproduzir</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.cpp" line="381"/>
-      <source>Playback text is empty</source>
-      <translation>O texto para reprodução está vazio</translation>
+        <location filename="../../src/settings/settingsdialog.cpp" line="381"/>
+        <source>Playback text is empty</source>
+        <translation>O texto para reprodução está vazio</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.cpp" line="391"/>
-      <source>Unable to detect language</source>
-      <translation>Não foi possível detectar o idioma</translation>
+        <location filename="../../src/settings/settingsdialog.cpp" line="391"/>
+        <source>Unable to detect language</source>
+        <translation>Não foi possível detetar o idioma</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.cpp" line="445"/>
-      <source>Checking for updates...</source>
-      <translation>Verificando atualizações...</translation>
+        <location filename="../../src/settings/settingsdialog.cpp" line="445"/>
+        <source>Checking for updates...</source>
+        <translation>A verificar por atualizações...</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.cpp" line="467"/>
-      <source>Update available!</source>
-      <translation>Atualização disponível!</translation>
+        <location filename="../../src/settings/settingsdialog.cpp" line="467"/>
+        <source>Update available!</source>
+        <translation>Atualização disponível!</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.cpp" line="473"/>
-      <source>No updates available.</source>
-      <translation>Não há atualizações disponíveis.</translation>
+        <location filename="../../src/settings/settingsdialog.cpp" line="473"/>
+        <source>No updates available.</source>
+        <translation>Não há atualizações disponíveis.</translation>
     </message>
     <message>
-      <location filename="../../src/settings/settingsdialog.cpp" line="571"/>
-      <source>Back</source>
-      <translation>Voltar</translation>
+        <location filename="../../src/settings/settingsdialog.cpp" line="571"/>
+        <source>Back</source>
+        <translation>Voltar</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>ShortcutsModel</name>
     <message>
-      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="138"/>
-      <source>Description</source>
-      <translation>Descrição</translation>
+        <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="138"/>
+        <source>Description</source>
+        <translation>Descrição</translation>
     </message>
     <message>
-      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="140"/>
-      <source>Shortcut</source>
-      <translation>Atalho</translation>
+        <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="140"/>
+        <source>Shortcut</source>
+        <translation>Atalho</translation>
     </message>
     <message>
-      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="34"/>
-      <source>Global</source>
-      <translation>Global</translation>
+        <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="34"/>
+        <source>Global</source>
+        <translation>Global</translation>
     </message>
     <message>
-      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="36"/>
-      <source>Translate selected text</source>
-      <translation>Traduzir texto selecionado</translation>
+        <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="36"/>
+        <source>Translate selected text</source>
+        <translation>Traduzir texto selecionado</translation>
     </message>
     <message>
-      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="39"/>
-      <source>Speak selected text</source>
-      <translation>Falar texto selecionado</translation>
+        <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="39"/>
+        <source>Speak selected text</source>
+        <translation>Falar texto selecionado</translation>
     </message>
     <message>
-      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="42"/>
-      <source>Speak translation of selected text</source>
-      <translation>Falar tradução do texto selecionado</translation>
+        <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="42"/>
+        <source>Speak translation of selected text</source>
+        <translation>Falar tradução do texto selecionado</translation>
     </message>
     <message>
-      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="45"/>
-      <source>Stop text speaking</source>
-      <translation>Parar a pronúncia do texto</translation>
+        <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="45"/>
+        <source>Stop text speaking</source>
+        <translation>Parar a fala do texto</translation>
     </message>
     <message>
-      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="51"/>
-      <source>Show main window</source>
-      <translation>Exibir janela principal</translation>
+        <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="51"/>
+        <source>Show main window</source>
+        <translation>Mostrar janela principal</translation>
     </message>
     <message>
-      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="54"/>
-      <source>Translate selected text and copy to clipboard</source>
-      <translation>Traduzir texto selecionado e copiar para área de transferência</translation>
+        <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="54"/>
+        <source>Translate selected text and copy to clipboard</source>
+        <translation>Traduzir texto selecionado e copiar para área de transferência</translation>
     </message>
     <message>
-      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="57"/>
-      <source>Recognize text in screen area</source>
-      <translation>Reconhecer texto na área da tela</translation>
+        <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="57"/>
+        <source>Recognize text in screen area</source>
+        <translation>Reconhecer texto na área do ecrã</translation>
     </message>
     <message>
-      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="60"/>
-      <source>Translate text in screen area</source>
-      <translation>Traduzir texto na área da tela</translation>
+        <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="60"/>
+        <source>Translate text in screen area</source>
+        <translation>Traduzir texto na área do ecrã</translation>
     </message>
     <message>
-      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="63"/>
-      <source>Recognize text in screen area with delay</source>
-      <translation>Reconhecer texto na área da tela com atraso</translation>
+        <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="63"/>
+        <source>Recognize text in screen area with delay</source>
+        <translation>Reconhecer texto na área do ecrã com atraso</translation>
     </message>
     <message>
-      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="66"/>
-      <source>Translate text in screen area with delay</source>
-      <translation>Traduzir texto na área da tela com atraso</translation>
+        <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="66"/>
+        <source>Translate text in screen area with delay</source>
+        <translation>Traduzir texto na área do ecrã com atraso</translation>
     </message>
     <message>
-      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="70"/>
-      <source>Main window</source>
-      <translation>Janela principal</translation>
+        <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="70"/>
+        <source>Main window</source>
+        <translation>Janela principal</translation>
     </message>
     <message>
-      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="72"/>
-      <source>Translate</source>
-      <translation>Traduzir</translation>
+        <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="72"/>
+        <source>Translate</source>
+        <translation>Traduzir</translation>
     </message>
     <message>
-      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="75"/>
-      <source>Swap languages</source>
-      <translation>Alternar idiomas</translation>
+        <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="75"/>
+        <source>Swap languages</source>
+        <translation>Alternar idiomas</translation>
     </message>
     <message>
-      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="78"/>
-      <source>Close window</source>
-      <translation>Fechar janela</translation>
+        <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="78"/>
+        <source>Close window</source>
+        <translation>Fechar janela</translation>
     </message>
     <message>
-      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="82"/>
-      <source>Source text</source>
-      <translation>Texto original</translation>
+        <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="82"/>
+        <source>Source text</source>
+        <translation>Texto original</translation>
     </message>
     <message>
-      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="48"/>
-      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="84"/>
-      <source>Speak / pause text speaking</source>
-      <translation>Falar / pausar texto falado</translation>
+        <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="48"/>
+        <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="84"/>
+        <source>Speak / pause text speaking</source>
+        <translation>Falar / pausar texto falado</translation>
     </message>
     <message>
-      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="90"/>
-      <source>Speak / pause speaking</source>
-      <translation>Falar / pausar fala</translation>
+        <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="90"/>
+        <source>Speak / pause speaking</source>
+        <translation>Falar / pausar fala</translation>
     </message>
     <message>
-      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="88"/>
-      <source>Translation</source>
-      <translation>Tradução</translation>
+        <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="88"/>
+        <source>Translation</source>
+        <translation>Tradução</translation>
     </message>
     <message>
-      <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="93"/>
-      <source>Copy to clipboard</source>
-      <translation>Copiar para a área de transferência</translation>
+        <location filename="../../src/settings/shortcutsmodel/shortcutsmodel.cpp" line="93"/>
+        <source>Copy to clipboard</source>
+        <translation>Copiar para a área de transferência</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>SnippingArea</name>
     <message>
-      <location filename="../../src/ocr/snippingarea.cpp" line="93"/>
-      <source>Unable to snip screen area</source>
-      <translation>Não é possível recortar área da tela</translation>
+        <location filename="../../src/ocr/snippingarea.cpp" line="93"/>
+        <source>Unable to snip screen area</source>
+        <translation>Não é possível recortar área do ecrã</translation>
     </message>
     <message>
-      <location filename="../../src/ocr/snippingarea.cpp" line="94"/>
-      <source>Received an invalid image of screen %1.</source>
-      <translation>Foi recebida uma imagem inválida da tela %1.</translation>
+        <location filename="../../src/ocr/snippingarea.cpp" line="94"/>
+        <source>Received an invalid image of screen %1.</source>
+        <translation>Recebida uma imagem inválida do ecrã %1.</translation>
     </message>
     <message>
-      <location filename="../../src/ocr/snippingarea.cpp" line="653"/>
-      <source>Click and drag to draw a selection rectangle,
+        <location filename="../../src/ocr/snippingarea.cpp" line="653"/>
+        <source>Click and drag to draw a selection rectangle,
 or press Esc to quit</source>
-      <translation>Clique e arraste para desenhar um retângulo de seleção,
+        <translation>Clique e arraste para desenhar um retângulo de seleção,
 ou pressione Esc para sair</translation>
     </message>
     <message>
-      <location filename="../../src/ocr/snippingarea.cpp" line="925"/>
-      <source>Confirm:</source>
-      <translation>Confirmar:</translation>
+        <location filename="../../src/ocr/snippingarea.cpp" line="925"/>
+        <source>Confirm:</source>
+        <translation>Confirmar:</translation>
     </message>
     <message>
-      <location filename="../../src/ocr/snippingarea.cpp" line="927"/>
-      <source>Release left-click</source>
-      <translation>Soltar botão esquerdo</translation>
+        <location filename="../../src/ocr/snippingarea.cpp" line="927"/>
+        <source>Release left-click</source>
+        <translation>Soltar botão esquerdo</translation>
     </message>
     <message>
-      <location filename="../../src/ocr/snippingarea.cpp" line="927"/>
-      <location filename="../../src/ocr/snippingarea.cpp" line="929"/>
-      <source>Enter</source>
-      <translation>Enter</translation>
+        <location filename="../../src/ocr/snippingarea.cpp" line="927"/>
+        <location filename="../../src/ocr/snippingarea.cpp" line="929"/>
+        <source>Enter</source>
+        <translation>Enter</translation>
     </message>
     <message>
-      <location filename="../../src/ocr/snippingarea.cpp" line="929"/>
-      <source>Double-click</source>
-      <translation>Clique duplo</translation>
+        <location filename="../../src/ocr/snippingarea.cpp" line="929"/>
+        <source>Double-click</source>
+        <translation>Clique duplo</translation>
     </message>
     <message>
-      <location filename="../../src/ocr/snippingarea.cpp" line="931"/>
-      <source>Create new selection rectangle:</source>
-      <translation>Criar novo retângulo de seleção:</translation>
+        <location filename="../../src/ocr/snippingarea.cpp" line="931"/>
+        <source>Create new selection rectangle:</source>
+        <translation>Criar novo retângulo de seleção:</translation>
     </message>
     <message>
-      <location filename="../../src/ocr/snippingarea.cpp" line="932"/>
-      <source>Drag outside selection rectangle</source>
-      <translation>Arraste para fora do retângulo de seleção</translation>
+        <location filename="../../src/ocr/snippingarea.cpp" line="932"/>
+        <source>Drag outside selection rectangle</source>
+        <translation>Arraste para fora do retângulo de seleção</translation>
     </message>
     <message>
-      <location filename="../../src/ocr/snippingarea.cpp" line="932"/>
-      <source>+ Shift: Magnifier</source>
-      <translation>+ Shift: Lupa</translation>
+        <location filename="../../src/ocr/snippingarea.cpp" line="932"/>
+        <source>+ Shift: Magnifier</source>
+        <translation>+ Shift: Lupa</translation>
     </message>
     <message>
-      <location filename="../../src/ocr/snippingarea.cpp" line="935"/>
-      <source>Move selection rectangle:</source>
-      <translation>Mover retângulo de seleção:</translation>
+        <location filename="../../src/ocr/snippingarea.cpp" line="935"/>
+        <source>Move selection rectangle:</source>
+        <translation>Mover retângulo de seleção:</translation>
     </message>
     <message>
-      <location filename="../../src/ocr/snippingarea.cpp" line="936"/>
-      <source>Drag inside selection rectangle</source>
-      <translation>Arrastar para dentro do retângulo de seleção</translation>
+        <location filename="../../src/ocr/snippingarea.cpp" line="936"/>
+        <source>Drag inside selection rectangle</source>
+        <translation>Arrastar para dentro do retângulo de seleção</translation>
     </message>
     <message>
-      <location filename="../../src/ocr/snippingarea.cpp" line="936"/>
-      <source>Arrow keys</source>
-      <translation>Teclas de seta</translation>
+        <location filename="../../src/ocr/snippingarea.cpp" line="936"/>
+        <source>Arrow keys</source>
+        <translation>Teclas de seta</translation>
     </message>
     <message>
-      <location filename="../../src/ocr/snippingarea.cpp" line="936"/>
-      <source>+ Shift: Move in 1 pixel steps</source>
-      <translation>+ Shift: Mover em 1 pixel</translation>
+        <location filename="../../src/ocr/snippingarea.cpp" line="936"/>
+        <source>+ Shift: Move in 1 pixel steps</source>
+        <translation>+ Shift: Mover em passos de 1 pixel</translation>
     </message>
     <message>
-      <location filename="../../src/ocr/snippingarea.cpp" line="938"/>
-      <source>Resize selection rectangle:</source>
-      <translation>Redimensionar retângulo de seleção:</translation>
+        <location filename="../../src/ocr/snippingarea.cpp" line="938"/>
+        <source>Resize selection rectangle:</source>
+        <translation>Redimensionar retângulo de seleção:</translation>
     </message>
     <message>
-      <location filename="../../src/ocr/snippingarea.cpp" line="939"/>
-      <source>Drag handles</source>
-      <translation>Alças de arrasto</translation>
+        <location filename="../../src/ocr/snippingarea.cpp" line="939"/>
+        <source>Drag handles</source>
+        <translation>Arrastar alças</translation>
     </message>
     <message>
-      <location filename="../../src/ocr/snippingarea.cpp" line="939"/>
-      <source>Arrow keys + Alt</source>
-      <translation>Teclas de seta + Alt</translation>
+        <location filename="../../src/ocr/snippingarea.cpp" line="939"/>
+        <source>Arrow keys + Alt</source>
+        <translation>Teclas de seta + Alt</translation>
     </message>
     <message>
-      <location filename="../../src/ocr/snippingarea.cpp" line="939"/>
-      <source>+ Shift: Resize in 1 pixel steps</source>
-      <translation>+ Shift: Redimensionar em 1 pixel</translation>
+        <location filename="../../src/ocr/snippingarea.cpp" line="939"/>
+        <source>+ Shift: Resize in 1 pixel steps</source>
+        <translation>+ Shift: Redimensionar em passos de 1 pixel</translation>
     </message>
     <message>
-      <location filename="../../src/ocr/snippingarea.cpp" line="941"/>
-      <source>Reset selection:</source>
-      <translation>Redefinir seleção:</translation>
+        <location filename="../../src/ocr/snippingarea.cpp" line="941"/>
+        <source>Reset selection:</source>
+        <translation>Redefinir seleção:</translation>
     </message>
     <message>
-      <location filename="../../src/ocr/snippingarea.cpp" line="942"/>
-      <source>Right-click</source>
-      <translation>Clique direito</translation>
+        <location filename="../../src/ocr/snippingarea.cpp" line="942"/>
+        <source>Right-click</source>
+        <translation>Clique direito</translation>
     </message>
     <message>
-      <location filename="../../src/ocr/snippingarea.cpp" line="945"/>
-      <source>Cancel:</source>
-      <translation>Cancelar:</translation>
+        <location filename="../../src/ocr/snippingarea.cpp" line="945"/>
+        <source>Cancel:</source>
+        <translation>Cancelar:</translation>
     </message>
     <message>
-      <location filename="../../src/ocr/snippingarea.cpp" line="946"/>
-      <source>Esc key</source>
-      <translation>Tecla Esc</translation>
+        <location filename="../../src/ocr/snippingarea.cpp" line="946"/>
+        <source>Esc key</source>
+        <translation>Tecla Esc</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>SpeakButtons</name>
     <message>
-      <location filename="../../src/speakbuttons.ui" line="24"/>
-      <source>Speak / pause text speaking</source>
-      <translation>Falar / pausar texto falado</translation>
+        <location filename="../../src/speakbuttons.ui" line="24"/>
+        <source>Speak / pause text speaking</source>
+        <translation>Falar / pausar texto falado</translation>
     </message>
     <message>
-      <location filename="../../src/speakbuttons.ui" line="34"/>
-      <source>Stop text speaking</source>
-      <translation>Parar a pronúncia do texto</translation>
+        <location filename="../../src/speakbuttons.ui" line="34"/>
+        <source>Stop text speaking</source>
+        <translation>Parar texto falado</translation>
     </message>
     <message>
-      <location filename="../../src/speakbuttons.cpp" line="130"/>
-      <source>No text specified</source>
-      <translation>Nenhum texto especificado</translation>
+        <location filename="../../src/speakbuttons.cpp" line="130"/>
+        <source>No text specified</source>
+        <translation>Nenhum texto especificado</translation>
     </message>
     <message>
-      <location filename="../../src/speakbuttons.cpp" line="130"/>
-      <source>Playback text is empty</source>
-      <translation>O texto para reprodução está vazio</translation>
+        <location filename="../../src/speakbuttons.cpp" line="130"/>
+        <source>Playback text is empty</source>
+        <translation>O texto para reprodução está vazio</translation>
     </message>
     <message>
-      <location filename="../../src/speakbuttons.cpp" line="137"/>
-      <source>Unable to generate URLs for TTS</source>
-      <translation>Não foi possível gerar URLs para TTS</translation>
+        <location filename="../../src/speakbuttons.cpp" line="137"/>
+        <source>Unable to generate URLs for TTS</source>
+        <translation>Não foi possível gerar URLs para TTS</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>TesseractParametersTableWidget</name>
     <message>
-      <location filename="../../src/settings/tesseractparameterstablewidget.cpp" line="29"/>
-      <source>Property</source>
-      <translation>Propriedade</translation>
+        <location filename="../../src/settings/tesseractparameterstablewidget.cpp" line="29"/>
+        <source>Property</source>
+        <translation>Propriedade</translation>
     </message>
     <message>
-      <location filename="../../src/settings/tesseractparameterstablewidget.cpp" line="29"/>
-      <source>Value</source>
-      <translation>Valor</translation>
+        <location filename="../../src/settings/tesseractparameterstablewidget.cpp" line="29"/>
+        <source>Value</source>
+        <translation>Valor</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>TranslationEdit</name>
     <message>
-      <location filename="../../src/translationedit.cpp" line="62"/>
-      <source>translation options:</source>
-      <translation>opções de tradução:</translation>
+        <location filename="../../src/translationedit.cpp" line="62"/>
+        <source>translation options:</source>
+        <translation>opções de tradução:</translation>
     </message>
     <message>
-      <location filename="../../src/translationedit.cpp" line="97"/>
-      <source>examples:</source>
-      <translation>exemplos:</translation>
+        <location filename="../../src/translationedit.cpp" line="97"/>
+        <source>examples:</source>
+        <translation>exemplos:</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>TrayIcon</name>
     <message>
-      <location filename="../../src/mainwindow.cpp" line="945"/>
-      <source>Invalid tray icon</source>
-      <translation>Ícone da área de notificação inválido</translation>
+        <location filename="../../src/mainwindow.cpp" line="945"/>
+        <source>Invalid tray icon</source>
+        <translation>Ícone da área de notificação inválido</translation>
     </message>
     <message>
-      <location filename="../../src/mainwindow.cpp" line="945"/>
-      <source>The specified icon &apos;%1&apos; is invalid. The default icon will be used.</source>
-      <translation>O ícone especificado &apos;%1&apos; é inválido. O ícone padrão será usado.</translation>
+        <location filename="../../src/mainwindow.cpp" line="945"/>
+        <source>The specified icon &apos;%1&apos; is invalid. The default icon will be used.</source>
+        <translation>O ícone especificado &apos;%1&apos; é inválido. O ícone padrão será usado.</translation>
     </message>
     <message>
-      <location filename="../../src/trayicon.cpp" line="32"/>
-      <location filename="../../src/trayicon.cpp" line="56"/>
-      <source>Show window</source>
-      <translation>Exibir janela</translation>
+        <location filename="../../src/trayicon.cpp" line="32"/>
+        <location filename="../../src/trayicon.cpp" line="56"/>
+        <source>Show window</source>
+        <translation>Mostrar janela</translation>
     </message>
     <message>
-      <location filename="../../src/trayicon.cpp" line="33"/>
-      <location filename="../../src/trayicon.cpp" line="57"/>
-      <source>Settings</source>
-      <translation>Configurações</translation>
+        <location filename="../../src/trayicon.cpp" line="33"/>
+        <location filename="../../src/trayicon.cpp" line="57"/>
+        <source>Settings</source>
+        <translation>Definições</translation>
     </message>
     <message>
-      <location filename="../../src/trayicon.cpp" line="34"/>
-      <location filename="../../src/trayicon.cpp" line="58"/>
-      <source>Quit</source>
-      <translation>Sair</translation>
+        <location filename="../../src/trayicon.cpp" line="34"/>
+        <location filename="../../src/trayicon.cpp" line="58"/>
+        <source>Quit</source>
+        <translation>Sair</translation>
     </message>
     <message>
-      <location filename="../../src/trayicon.cpp" line="63"/>
-      <source>Translation result</source>
-      <translation>Resultado da tradução</translation>
+        <location filename="../../src/trayicon.cpp" line="63"/>
+        <source>Translation result</source>
+        <translation>Resultado da tradução</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>UnixAutostartManager</name>
     <message>
-      <location filename="../../src/settings/autostartmanager/unixautostartmanager.cpp" line="48"/>
-      <source>Unable to create %1</source>
-      <translation>Não foi possível criar %1</translation>
+        <location filename="../../src/settings/autostartmanager/unixautostartmanager.cpp" line="48"/>
+        <source>Unable to create %1</source>
+        <translation>Não foi possível criar %1</translation>
     </message>
     <message>
-      <location filename="../../src/settings/autostartmanager/unixautostartmanager.cpp" line="55"/>
-      <source>Unable to copy %1 to %2</source>
-      <translation>Não foi possível copiar %1 para %2</translation>
+        <location filename="../../src/settings/autostartmanager/unixautostartmanager.cpp" line="55"/>
+        <source>Unable to copy %1 to %2</source>
+        <translation>Não foi possível copiar %1 para %2</translation>
     </message>
     <message>
-      <location filename="../../src/settings/autostartmanager/unixautostartmanager.cpp" line="60"/>
-      <source>Unable to remove %1 from %2</source>
-      <translation>Não foi possível remover %1 de %2</translation>
+        <location filename="../../src/settings/autostartmanager/unixautostartmanager.cpp" line="60"/>
+        <source>Unable to remove %1 from %2</source>
+        <translation>Não foi possível remover %1 de %2</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>UpdaterDialog</name>
     <message>
-      <location filename="../../src/updaterdialog.ui" line="90"/>
-      <source>Cancel download</source>
-      <translation>Cancelar download</translation>
+        <location filename="../../src/updaterdialog.ui" line="90"/>
+        <source>Cancel download</source>
+        <translation>Cancelar transferência</translation>
     </message>
     <message>
-      <location filename="../../src/updaterdialog.ui" line="93"/>
-      <source>Cancel</source>
-      <translation>Cancelar</translation>
+        <location filename="../../src/updaterdialog.ui" line="93"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
     </message>
     <message>
-      <location filename="../../src/updaterdialog.ui" line="34"/>
-      <source>Download the installer to the Downloads folder</source>
-      <translation>Baixar o instalador na pasta de Downloads</translation>
+        <location filename="../../src/updaterdialog.ui" line="34"/>
+        <source>Download the installer to the Downloads folder</source>
+        <translation>Transferir o instalador para a pasta de Transferências</translation>
     </message>
     <message>
-      <location filename="../../src/updaterdialog.ui" line="37"/>
-      <source>Download</source>
-      <translation>Baixar</translation>
+        <location filename="../../src/updaterdialog.ui" line="37"/>
+        <source>Download</source>
+        <translation>Transferir</translation>
     </message>
     <message>
-      <location filename="../../src/updaterdialog.ui" line="24"/>
-      <source>Exit the program and run the installer</source>
-      <translation>Sair do programa e executar o instalador</translation>
+        <location filename="../../src/updaterdialog.ui" line="24"/>
+        <source>Exit the program and run the installer</source>
+        <translation>Sair do programa e executar o instalador</translation>
     </message>
     <message>
-      <location filename="../../src/updaterdialog.ui" line="27"/>
-      <source>Install</source>
-      <translation>Instalar</translation>
+        <location filename="../../src/updaterdialog.ui" line="27"/>
+        <source>Install</source>
+        <translation>Instalar</translation>
     </message>
     <message>
-      <location filename="../../src/updaterdialog.ui" line="44"/>
-      <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A new version of Crow Translate is available! Updates add functionality and improve the stability of the application. Most often.&lt;br/&gt;You can also download the release manually from this &lt;a href=&quot;https://github.com/crow-translate/crow-translate/releases&quot;&gt;link&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Uma nova versão do Crow Tradutor está disponível! Atualizações adicionam funcionalidades e melhoram a estabilidade do aplicativo. Com bastante frequência.&lt;br/&gt;Você também pode baixar a versão manualmente a partir de &lt;a href=&quot;https://github.com/crow-translate/crow-translate/releases&quot;&gt;link&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../../src/updaterdialog.ui" line="44"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A new version of Crow Translate is available! Updates add functionality and improve the stability of the application. Most often.&lt;br/&gt;You can also download the release manually from this &lt;a href=&quot;https://github.com/crow-translate/crow-translate/releases&quot;&gt;link&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Uma nova versão do Crow Translate está disponível! Atualizações adicionam funcionalidades e melhoram a estabilidade da aplicação.&lt;br/&gt;Também pode transferir a versão manualmente a partir de &lt;a href=&quot;https://github.com/crow-translate/crow-translate/releases&quot;&gt;link&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-      <location filename="../../src/updaterdialog.ui" line="67"/>
-      <source>Close this window</source>
-      <translation>Fechar essa janela</translation>
+        <location filename="../../src/updaterdialog.ui" line="67"/>
+        <source>Close this window</source>
+        <translation>Fechar esta janela</translation>
     </message>
     <message>
-      <location filename="../../src/updaterdialog.ui" line="70"/>
-      <source>Update later</source>
-      <translation>Atualizar depois</translation>
+        <location filename="../../src/updaterdialog.ui" line="70"/>
+        <source>Update later</source>
+        <translation>Atualizar depois</translation>
     </message>
     <message>
-      <location filename="../../src/updaterdialog.ui" line="109"/>
-      <source>Current version:</source>
-      <translation>Versão Atual:</translation>
+        <location filename="../../src/updaterdialog.ui" line="109"/>
+        <source>Current version:</source>
+        <translation>Versão atual:</translation>
     </message>
     <message>
-      <location filename="../../src/updaterdialog.ui" line="129"/>
-      <source>Available version:</source>
-      <translation>Versão disponível:</translation>
+        <location filename="../../src/updaterdialog.ui" line="129"/>
+        <source>Available version:</source>
+        <translation>Versão disponível:</translation>
     </message>
     <message>
-      <location filename="../../src/updaterdialog.cpp" line="59"/>
-      <location filename="../../src/updaterdialog.cpp" line="62"/>
-      <source>Changelog:</source>
-      <translation>Registro de alterações:</translation>
+        <location filename="../../src/updaterdialog.cpp" line="59"/>
+        <location filename="../../src/updaterdialog.cpp" line="62"/>
+        <source>Changelog:</source>
+        <translation>Histórico de alterações:</translation>
     </message>
     <message>
-      <location filename="../../src/updaterdialog.cpp" line="132"/>
-      <source>Downloading is complete</source>
-      <translation>O download está completo</translation>
+        <location filename="../../src/updaterdialog.cpp" line="132"/>
+        <source>Downloading is complete</source>
+        <translation>Transferência está completada</translation>
     </message>
     <message>
-      <location filename="../../src/updaterdialog.cpp" line="88"/>
-      <source>Unable to write file</source>
-      <translation>Não foi possível gravar o arquivo</translation>
+        <location filename="../../src/updaterdialog.cpp" line="88"/>
+        <source>Unable to write file</source>
+        <translation>Não foi possível escrever ficheiro</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>WaylandGnomeScreenGrabber</name>
     <message>
-      <location filename="../../src/ocr/screengrabbers/waylandgnomescreengrabber.cpp" line="60"/>
-      <source>GNOME failed to take screenshot.</source>
-      <translation>GNOME não conseguiu fazer captura de tela.</translation>
+        <location filename="../../src/ocr/screengrabbers/waylandgnomescreengrabber.cpp" line="60"/>
+        <source>GNOME failed to take screenshot.</source>
+        <translation>GNOME falhou captura de ecrã.</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>WaylandPlasmaScreenGrabber</name>
     <message>
-      <location filename="../../src/ocr/screengrabbers/waylandplasmascreengrabber.cpp" line="61"/>
-      <source>Unable to create pipe: %1.</source>
-      <translation>Não foi possível criar o pipe: %1.</translation>
+        <location filename="../../src/ocr/screengrabbers/waylandplasmascreengrabber.cpp" line="61"/>
+        <source>Unable to create pipe: %1.</source>
+        <translation>Não foi possível criar pipe: %1.</translation>
     </message>
     <message>
-      <location filename="../../src/ocr/screengrabbers/waylandplasmascreengrabber.cpp" line="105"/>
-      <source>Unable to wait for socket readiness: %1.</source>
-      <translation>Não foi possível esperar pela prontidão do soquete: %1.</translation>
+        <location filename="../../src/ocr/screengrabbers/waylandplasmascreengrabber.cpp" line="105"/>
+        <source>Unable to wait for socket readiness: %1.</source>
+        <translation>Não foi possível esperar pela prontidão do socket: %1.</translation>
     </message>
     <message>
-      <location filename="../../src/ocr/screengrabbers/waylandplasmascreengrabber.cpp" line="110"/>
-      <source>Timeout reading from pipe.</source>
-      <translation>Tempo limite de leitura do pipe.</translation>
+        <location filename="../../src/ocr/screengrabbers/waylandplasmascreengrabber.cpp" line="110"/>
+        <source>Timeout reading from pipe.</source>
+        <translation>Tempo limite de leitura do pipe.</translation>
     </message>
     <message>
-      <location filename="../../src/ocr/screengrabbers/waylandplasmascreengrabber.cpp" line="116"/>
-      <source>Unable to read data from socket: %1.</source>
-      <translation>Não foi possível ler dados do socket: %1.</translation>
+        <location filename="../../src/ocr/screengrabbers/waylandplasmascreengrabber.cpp" line="116"/>
+        <source>Unable to read data from socket: %1.</source>
+        <translation>Não foi possível ler dados do socket: %1.</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>WaylandPortalScreenGrabber</name>
     <message>
-      <location filename="../../src/ocr/screengrabbers/waylandportalscreengrabber.cpp" line="72"/>
-      <source>Unable to subscribe to response from xdg-desktop-portal.</source>
-      <translation>Não é possível assinar a resposta de xdg-desktop-portal.</translation>
+        <location filename="../../src/ocr/screengrabbers/waylandportalscreengrabber.cpp" line="72"/>
+        <source>Unable to subscribe to response from xdg-desktop-portal.</source>
+        <translation>Não é possível subscrever a resposta de xdg-desktop-portal.</translation>
     </message>
     <message>
-      <location filename="../../src/ocr/screengrabbers/waylandportalscreengrabber.cpp" line="92"/>
-      <source>Received an empty path from xdg-desktop-portal.</source>
-      <translation>Caminho vazio recebido de xdg-desktop-portal.</translation>
+        <location filename="../../src/ocr/screengrabbers/waylandportalscreengrabber.cpp" line="92"/>
+        <source>Received an empty path from xdg-desktop-portal.</source>
+        <translation>Caminho vazio recebido de xdg-desktop-portal.</translation>
     </message>
-  </context>
+</context>
 </TS>


### PR DESCRIPTION
Portuguese European (**pt-PT)** is different from Portuguese Brazilian (**pt-BR**). I noticed that only pt-BR existed, so I did a pt-PT translation.
**NOTE:** As is stands, (before this commit, see attached pic), the Portuguese flag is (wrongly) corresponding to the only existing until now Portuguese BR, so if you agree to add my pt-PT translation, you should change it to the Brazilian flag...
In the end the correct standard is: **Portuguese** pt-PT (Portuguese flag) ; **Portuguese Brazilian** pt-BR (Brazilian flag).
Best regards
Ricardo Simões
xmcorporation.com
![Captura de ecrã_2022-08-08_17-31-21](https://user-images.githubusercontent.com/16106645/183467826-cc291cdd-0263-454e-9422-fe3b440e78af.png)
