### PR TITLE
Make AppImages updateable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,5 +127,5 @@ jobs:
       - name: Upload
         uses: AButler/upload-release-assets@v2.0
         with:
-          files: build/{crow-translate*.exe,*.AppImage,*.deb,*.rpm,*.7z}
+          files: build/{crow-translate*.exe,*.AppImage,*.AppImage.zsync,*.deb,*.rpm,*.7z}
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/cmake/AppImage.cmake
+++ b/cmake/AppImage.cmake
@@ -4,5 +4,6 @@ find_program(LINUXDEPLOY_EXECUTABLE
 )
 
 execute_process(COMMAND ${CMAKE_COMMAND} -E env EXTRA_QT_PLUGINS=multimediawidgets\;svg VERSION=${CPACK_PACKAGE_VERSION}
+  UPDATE_INFORMATION=gh-releases-zsync|crow-translate|crow-translate|latest|Crow_Translate-*-x86_64.AppImage.zsync
   ${LINUXDEPLOY_EXECUTABLE} --appdir=${CPACK_TEMPORARY_DIRECTORY} --plugin=qt --plugin=gstreamer --output=appimage
 )


### PR DESCRIPTION
This is done by embedding update information inside the AppImage itself, which for linuxdeploy can be done using the `UPDATE_INFORMATION` variable as described in the [AppImage documentation](https://docs.appimage.org/packaging-guide/optional/updates.html#using-linuxdeploy).
Thus, this adds a `.zsync` file to the release section, which makes it easier to update to newer versions without re-installing the whole file using tools like [AppImageUpdate](https://github.com/AppImage/AppImageUpdate).

To test this, first install [appimageupdatetool](https://github.com/AppImage/AppImageUpdate/releases), and make it executable, then install this version of [Crow_Translate-2.9.12-x86_64.AppImage](https://github.com/eljamm/crow-translate/releases/download/2.9.12/Crow_Translate-2.9.12-x86_64.AppImage).

To check the update information, run :
```sh
$ ./appimageupdatetool -d Crow_Translate-2.9.12-x86_64.AppImage
```
We can see from the output that the `2.9.13` update is available :
```sh
Assembled ZSync URL: https://github.com/eljamm/crow-translate/releases/download/2.9.13/Crow_Translate-2.9.13-x86_64.AppImage.zsync
```
To update the current file from `2.9.12` to `2.9.13`, run :
```sh
$ ./appimageupdatetool Crow_Translate-2.9.12-x86_64.AppImage
```
Running this with `time` shows us a faster update than re-downloading the whole AppImage :
```sh
real	0m5.211s
user	0m1.080s
sys	0m0.335s
```