### PR TITLE
Added an option to select regional voice for Google

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -989,6 +989,10 @@ void MainWindow::loadAppSettings()
     // TTS
     ui->sourceSpeakButtons->setVoice(QOnlineTranslator::Yandex, settings.voice(QOnlineTranslator::Yandex));
     ui->sourceSpeakButtons->setEmotion(QOnlineTranslator::Yandex, settings.emotion(QOnlineTranslator::Yandex));
+    ui->sourceSpeakButtons->setRegions(QOnlineTranslator::Google, settings.regions(QOnlineTranslator::Google));
+    ui->translationSpeakButtons->setVoice(QOnlineTranslator::Yandex, settings.voice(QOnlineTranslator::Yandex));
+    ui->translationSpeakButtons->setEmotion(QOnlineTranslator::Yandex, settings.emotion(QOnlineTranslator::Yandex));
+    ui->translationSpeakButtons->setRegions(QOnlineTranslator::Google, settings.regions(QOnlineTranslator::Google));
 
     // Connection
     if (const QNetworkProxy::ProxyType proxyType = settings.proxyType(); proxyType == QNetworkProxy::DefaultProxy) {

--- a/src/settings/appsettings.cpp
+++ b/src/settings/appsettings.cpp
@@ -668,7 +668,7 @@ QMap<QOnlineTranslator::Language, QLocale::Country> AppSettings::regions(QOnline
 {
     switch (engine) {
     case QOnlineTranslator::Google: {
-        const QMap<QString, QVariant> regionSettings(m_settings->value(QStringLiteral("TTS/GoogleRegions")).value<QMap<QString, QVariant>>());
+        const auto regionSettings(m_settings->value(QStringLiteral("TTS/GoogleRegions")).value<QMap<QString, QVariant>>());
         QMap<QOnlineTranslator::Language, QLocale::Country> regions;
         for (const QOnlineTranslator::Language lang : QOnlineTts::validRegions().keys())
             regions[lang] = regionSettings.value(QOnlineTranslator::languageName(lang)).value<QLocale::Country>();

--- a/src/settings/appsettings.cpp
+++ b/src/settings/appsettings.cpp
@@ -669,9 +669,8 @@ QMap<QOnlineTranslator::Language, QLocale::Country> AppSettings::regions(QOnline
     switch (engine) {
     case QOnlineTranslator::Google: {
         QMap<QOnlineTranslator::Language, QLocale::Country> regions;
-        for (int i = 1; i <= QOnlineTranslator::Zulu; ++i)
-            if (!QOnlineTts::validRegions(static_cast<QOnlineTranslator::Language>(i)).isEmpty())
-                regions[static_cast<QOnlineTranslator::Language>(i)] = m_settings->value(QString("TTS/GoogleRegion/%1").arg(QOnlineTranslator::languageName(static_cast<QOnlineTranslator::Language>(i))), QLocale::AnyCountry).value<QLocale::Country>();
+        for (const QOnlineTranslator::Language lang : QOnlineTts::validRegions().keys())
+            regions[lang] = m_settings->value(QString("TTS/GoogleRegion/%1").arg(QOnlineTranslator::languageName(lang)), QLocale::AnyCountry).value<QLocale::Country>();
         return regions;
     }
     case QOnlineTranslator::Bing:
@@ -689,8 +688,7 @@ void AppSettings::setRegions(QOnlineTranslator::Engine engine, const QMap<QOnlin
     switch (engine) {
     case QOnlineTranslator::Google:
         for (auto it = regions.cbegin(); it != regions.cend(); ++it)
-            if (!QOnlineTts::validRegions(it.key()).isEmpty())
-                m_settings->setValue(QString("TTS/GoogleRegion/%1").arg(QOnlineTranslator::languageName(it.key())), it.value());
+            m_settings->setValue(QString("TTS/GoogleRegion/%1").arg(QOnlineTranslator::languageName(it.key())), it.value());
         return;
     default:
         Q_UNREACHABLE();

--- a/src/settings/appsettings.cpp
+++ b/src/settings/appsettings.cpp
@@ -664,6 +664,51 @@ QOnlineTts::Emotion AppSettings::defaultEmotion(QOnlineTranslator::Engine engine
     }
 }
 
+QMap<QOnlineTranslator::Language, QLocale::Country> AppSettings::regions(QOnlineTranslator::Engine engine) const
+{
+    switch (engine) {
+    case QOnlineTranslator::Google: {
+        QMap<QOnlineTranslator::Language, QLocale::Country> regions;
+        for (int i = 1; i <= QOnlineTranslator::Zulu; ++i)
+            regions[static_cast<QOnlineTranslator::Language>(i)] = m_settings->value("Translation/GoogleRegion/" + QOnlineTranslator::languageName(static_cast<QOnlineTranslator::Language>(i)), QLocale::AnyCountry).value<QLocale::Country>();
+        return regions;
+    }
+    case QOnlineTranslator::Bing:
+    case QOnlineTranslator::Yandex:
+    case QOnlineTranslator::LibreTranslate:
+    case QOnlineTranslator::Lingva:
+        return {};
+    default:
+        Q_UNREACHABLE();
+    }
+}
+
+void AppSettings::setRegions(QOnlineTranslator::Engine engine, const QMap<QOnlineTranslator::Language, QLocale::Country> &regions)
+{
+    switch (engine) {
+    case QOnlineTranslator::Google:
+        for (auto it = regions.cbegin(); it != regions.cend(); ++it)
+            m_settings->setValue("Translation/GoogleRegion/" + QOnlineTranslator::languageName(it.key()), it.value());
+        return;
+    default:
+        Q_UNREACHABLE();
+    }
+}
+
+QMap<QOnlineTranslator::Language, QLocale::Country> AppSettings::defaultRegions(QOnlineTranslator::Engine engine)
+{
+    switch (engine) {
+    case QOnlineTranslator::Google:
+    case QOnlineTranslator::Bing:
+    case QOnlineTranslator::Yandex:
+    case QOnlineTranslator::LibreTranslate:
+    case QOnlineTranslator::Lingva:
+        return {};
+    default:
+        Q_UNREACHABLE();
+    }
+}
+
 QNetworkProxy::ProxyType AppSettings::proxyType() const
 {
     return static_cast<QNetworkProxy::ProxyType>(m_settings->value(QStringLiteral("Connection/ProxyType"), defaultProxyType()).toInt());

--- a/src/settings/appsettings.cpp
+++ b/src/settings/appsettings.cpp
@@ -668,9 +668,10 @@ QMap<QOnlineTranslator::Language, QLocale::Country> AppSettings::regions(QOnline
 {
     switch (engine) {
     case QOnlineTranslator::Google: {
+        const QMap<QString, QVariant> regionSettings(m_settings->value(QStringLiteral("TTS/GoogleRegions")).value<QMap<QString, QVariant>>());
         QMap<QOnlineTranslator::Language, QLocale::Country> regions;
         for (const QOnlineTranslator::Language lang : QOnlineTts::validRegions().keys())
-            regions[lang] = m_settings->value(QString("TTS/GoogleRegion/%1").arg(QOnlineTranslator::languageName(lang)), QLocale::AnyCountry).value<QLocale::Country>();
+            regions[lang] = regionSettings.value(QOnlineTranslator::languageName(lang)).value<QLocale::Country>();
         return regions;
     }
     case QOnlineTranslator::Bing:
@@ -686,10 +687,14 @@ QMap<QOnlineTranslator::Language, QLocale::Country> AppSettings::regions(QOnline
 void AppSettings::setRegions(QOnlineTranslator::Engine engine, const QMap<QOnlineTranslator::Language, QLocale::Country> &regions)
 {
     switch (engine) {
-    case QOnlineTranslator::Google:
+    case QOnlineTranslator::Google: {
+        QMap<QString, QVariant> regionSettings;
         for (auto it = regions.cbegin(); it != regions.cend(); ++it)
-            m_settings->setValue(QString("TTS/GoogleRegion/%1").arg(QOnlineTranslator::languageName(it.key())), it.value());
+            regionSettings[QOnlineTranslator::languageName(it.key())] = it.value();
+
+        m_settings->setValue(QStringLiteral("TTS/GoogleRegions"), regionSettings);
         return;
+    }
     default:
         Q_UNREACHABLE();
     }

--- a/src/settings/appsettings.cpp
+++ b/src/settings/appsettings.cpp
@@ -589,7 +589,7 @@ QOnlineTts::Voice AppSettings::voice(QOnlineTranslator::Engine engine) const
     case QOnlineTranslator::Lingva:
         return QOnlineTts::NoVoice;
     case QOnlineTranslator::Yandex:
-        return m_settings->value(QStringLiteral("Translation/YandexVoice"), defaultVoice(engine)).value<QOnlineTts::Voice>();
+        return m_settings->value(QStringLiteral("TTS/YandexVoice"), defaultVoice(engine)).value<QOnlineTts::Voice>();
     default:
         Q_UNREACHABLE();
     }
@@ -599,7 +599,7 @@ void AppSettings::setVoice(QOnlineTranslator::Engine engine, QOnlineTts::Voice v
 {
     switch (engine) {
     case QOnlineTranslator::Yandex:
-        m_settings->setValue(QStringLiteral("Translation/YandexVoice"), voice);
+        m_settings->setValue(QStringLiteral("TTS/YandexVoice"), voice);
         return;
     default:
         // Currently only Yandex have voice settings
@@ -631,7 +631,7 @@ QOnlineTts::Emotion AppSettings::emotion(QOnlineTranslator::Engine engine) const
     case QOnlineTranslator::Lingva:
         return QOnlineTts::NoEmotion;
     case QOnlineTranslator::Yandex:
-        return m_settings->value(QStringLiteral("Translation/YandexEmotion"), defaultEmotion(engine)).value<QOnlineTts::Emotion>();
+        return m_settings->value(QStringLiteral("TTS/YandexEmotion"), defaultEmotion(engine)).value<QOnlineTts::Emotion>();
     default:
         Q_UNREACHABLE();
     }
@@ -641,7 +641,7 @@ void AppSettings::setEmotion(QOnlineTranslator::Engine engine, QOnlineTts::Emoti
 {
     switch (engine) {
     case QOnlineTranslator::Yandex:
-        m_settings->setValue(QStringLiteral("Translation/YandexEmotion"), emotion);
+        m_settings->setValue(QStringLiteral("TTS/YandexEmotion"), emotion);
         return;
     default:
         // Currently only Yandex have emotion settings
@@ -670,7 +670,8 @@ QMap<QOnlineTranslator::Language, QLocale::Country> AppSettings::regions(QOnline
     case QOnlineTranslator::Google: {
         QMap<QOnlineTranslator::Language, QLocale::Country> regions;
         for (int i = 1; i <= QOnlineTranslator::Zulu; ++i)
-            regions[static_cast<QOnlineTranslator::Language>(i)] = m_settings->value("Translation/GoogleRegion/" + QOnlineTranslator::languageName(static_cast<QOnlineTranslator::Language>(i)), QLocale::AnyCountry).value<QLocale::Country>();
+            if (!QOnlineTts::validRegions(static_cast<QOnlineTranslator::Language>(i)).isEmpty())
+                regions[static_cast<QOnlineTranslator::Language>(i)] = m_settings->value(QString("TTS/GoogleRegion/%1").arg(QOnlineTranslator::languageName(static_cast<QOnlineTranslator::Language>(i))), QLocale::AnyCountry).value<QLocale::Country>();
         return regions;
     }
     case QOnlineTranslator::Bing:
@@ -688,7 +689,8 @@ void AppSettings::setRegions(QOnlineTranslator::Engine engine, const QMap<QOnlin
     switch (engine) {
     case QOnlineTranslator::Google:
         for (auto it = regions.cbegin(); it != regions.cend(); ++it)
-            m_settings->setValue("Translation/GoogleRegion/" + QOnlineTranslator::languageName(it.key()), it.value());
+            if (!QOnlineTts::validRegions(it.key()).isEmpty())
+                m_settings->setValue(QString("TTS/GoogleRegion/%1").arg(QOnlineTranslator::languageName(it.key())), it.value());
         return;
     default:
         Q_UNREACHABLE();

--- a/src/settings/appsettings.h
+++ b/src/settings/appsettings.h
@@ -221,6 +221,10 @@ public:
     void setEmotion(QOnlineTranslator::Engine engine, QOnlineTts::Emotion emotion);
     static QOnlineTts::Emotion defaultEmotion(QOnlineTranslator::Engine engine);
 
+    QMap<QOnlineTranslator::Language, QLocale::Country> regions(QOnlineTranslator::Engine engine) const;
+    void setRegions(QOnlineTranslator::Engine engine, const QMap<QOnlineTranslator::Language, QLocale::Country> &regions);
+    static QMap<QOnlineTranslator::Language, QLocale::Country> defaultRegions(QOnlineTranslator::Engine engine);
+
     // Connection settings
     QNetworkProxy::ProxyType proxyType() const;
     void setProxyType(QNetworkProxy::ProxyType type);

--- a/src/settings/settingsdialog.cpp
+++ b/src/settings/settingsdialog.cpp
@@ -397,7 +397,7 @@ void SettingsDialog::speakYandexTestText()
 
 void SettingsDialog::onGoogleLanguageSelectionChanged(int languageIndex)
 {
-    const QOnlineTranslator::Language configuredLang = ui->googleLanguageComboBox->itemData(languageIndex).value<QOnlineTranslator::Language>();
+    const auto configuredLang = ui->googleLanguageComboBox->itemData(languageIndex).value<QOnlineTranslator::Language>();
     const QLocale::Country langRegion = ui->googlePlayerButtons->regions(QOnlineTranslator::Google)[configuredLang]; // It will be lost after googleRegionComboBox is changed if not stored here
 
     ui->googleRegionComboBox->clear();
@@ -415,7 +415,7 @@ void SettingsDialog::onGoogleLanguageSelectionChanged(int languageIndex)
 
 void SettingsDialog::saveGoogleEngineRegion(int region)
 {
-    const QOnlineTranslator::Language lang = ui->googleLanguageComboBox->currentData().value<QOnlineTranslator::Language>();
+    const auto lang = ui->googleLanguageComboBox->currentData().value<QOnlineTranslator::Language>();
 
     QMap<QOnlineTranslator::Language, QLocale::Country> regionSettings = ui->googlePlayerButtons->regions(QOnlineTranslator::Google);
     regionSettings[lang] = ui->googleRegionComboBox->itemData(region).value<QLocale::Country>();

--- a/src/settings/settingsdialog.cpp
+++ b/src/settings/settingsdialog.cpp
@@ -710,7 +710,7 @@ void SettingsDialog::loadSettings()
 
 void SettingsDialog::detectTestTextLanguage(QOnlineTranslator *translator, QOnlineTranslator::Engine engine)
 {
-    auto const &testText = ((engine == QOnlineTranslator::Yandex) ? ui->yandexTestSpeechEdit->text() : ui->googleTestSpeechEdit->text()); // There are now only two engines
+    const QString &testText = ((engine == QOnlineTranslator::Yandex) ? ui->yandexTestSpeechEdit->text() : ui->googleTestSpeechEdit->text()); // There are now only two engines
 
     if (testText.isEmpty()) {
         QMessageBox::information(this, tr("Nothing to play"), tr("Playback text is empty"));

--- a/src/settings/settingsdialog.cpp
+++ b/src/settings/settingsdialog.cpp
@@ -387,12 +387,12 @@ void SettingsDialog::saveYandexEngineEmotion(int emotion)
 // To play test text
 void SettingsDialog::detectYandexTextLanguage()
 {
-    detectTestTextLanguage(m_yandexTranslator, QOnlineTranslator::Yandex);
+    detectTestTextLanguage(*m_yandexTranslator, QOnlineTranslator::Yandex);
 }
 
 void SettingsDialog::speakYandexTestText()
 {
-    speakTestText(m_yandexTranslator, QOnlineTranslator::Yandex);
+    speakTestText(*m_yandexTranslator, QOnlineTranslator::Yandex);
 }
 
 void SettingsDialog::onGoogleLanguageSelectionChanged(int languageIndex)
@@ -425,12 +425,12 @@ void SettingsDialog::saveGoogleEngineRegion(int region)
 
 void SettingsDialog::detectGoogleTextLanguage()
 {
-    detectTestTextLanguage(m_googleTranslator, QOnlineTranslator::Google);
+    detectTestTextLanguage(*m_googleTranslator, QOnlineTranslator::Google);
 }
 
 void SettingsDialog::speakGoogleTestText()
 {
-    speakTestText(m_googleTranslator, QOnlineTranslator::Google);
+    speakTestText(*m_googleTranslator, QOnlineTranslator::Google);
 }
 
 void SettingsDialog::loadShortcut(ShortcutItem *item)
@@ -708,7 +708,7 @@ void SettingsDialog::loadSettings()
     ui->shortcutsTreeView->model()->loadShortcuts(settings);
 }
 
-void SettingsDialog::detectTestTextLanguage(QOnlineTranslator *translator, QOnlineTranslator::Engine engine)
+void SettingsDialog::detectTestTextLanguage(QOnlineTranslator &translator, QOnlineTranslator::Engine engine)
 {
     const QString &testText = ((engine == QOnlineTranslator::Yandex) ? ui->yandexTestSpeechEdit->text() : ui->googleTestSpeechEdit->text()); // There are now only two engines
 
@@ -717,20 +717,20 @@ void SettingsDialog::detectTestTextLanguage(QOnlineTranslator *translator, QOnli
         return;
     }
 
-    translator->detectLanguage(testText, engine);
+    translator.detectLanguage(testText, engine);
 }
 
-void SettingsDialog::speakTestText(QOnlineTranslator *translator, QOnlineTranslator::Engine engine)
+void SettingsDialog::speakTestText(QOnlineTranslator &translator, QOnlineTranslator::Engine engine)
 {
-    if (translator->error() != QOnlineTranslator::NoError) {
-        QMessageBox::critical(this, tr("Unable to detect language"), translator->errorString());
+    if (translator.error() != QOnlineTranslator::NoError) {
+        QMessageBox::critical(this, tr("Unable to detect language"), translator.errorString());
         return;
     }
 
     if (engine == QOnlineTranslator::Yandex)
-        ui->yandexPlayerButtons->speak(ui->yandexTestSpeechEdit->text(), translator->sourceLanguage(), QOnlineTranslator::Yandex);
+        ui->yandexPlayerButtons->speak(ui->yandexTestSpeechEdit->text(), translator.sourceLanguage(), QOnlineTranslator::Yandex);
     else if (engine == QOnlineTranslator::Google)
-        ui->googlePlayerButtons->speak(ui->googleTestSpeechEdit->text(), translator->sourceLanguage(), QOnlineTranslator::Google);
+        ui->googlePlayerButtons->speak(ui->googleTestSpeechEdit->text(), translator.sourceLanguage(), QOnlineTranslator::Google);
     else
         Q_UNREACHABLE();
 }

--- a/src/settings/settingsdialog.cpp
+++ b/src/settings/settingsdialog.cpp
@@ -403,7 +403,7 @@ void SettingsDialog::onGoogleLanguageSelectionChanged(int languageIndex)
     ui->googleRegionComboBox->clear();
 
     ui->googleRegionComboBox->addItem(tr("Default region"), QLocale::AnyCountry);
-    for (const QLocale::Country validRegion : QOnlineTts::validRegions().value(configuredLang)) {
+    for (QLocale::Country validRegion : QOnlineTts::validRegions().value(configuredLang)) {
         if (validRegion == QLocale::China)
             ui->googleRegionComboBox->addItem(tr("Mandarin (China)"), QLocale::China); // for now there's only one Chinese dialect supported
         else

--- a/src/settings/settingsdialog.cpp
+++ b/src/settings/settingsdialog.cpp
@@ -109,7 +109,7 @@ SettingsDialog::SettingsDialog(MainWindow *parent)
 
     ui->ocrLanguagesListWidget->addLanguages(parent->ocr()->availableLanguages());
 
-    for (const QOnlineTranslator::Language configurableLang : QOnlineTts::validRegions().keys())
+    for (QOnlineTranslator::Language configurableLang : QOnlineTts::validRegions().keys())
         ui->googleLanguageComboBox->addItem(QOnlineTranslator::languageName(configurableLang), configurableLang);
 
     // Sort languages in comboboxes alphabetically

--- a/src/settings/settingsdialog.h
+++ b/src/settings/settingsdialog.h
@@ -75,6 +75,11 @@ private slots:
     void detectYandexTextLanguage();
     void speakYandexTestText();
 
+    void onGoogleLanguageSelectionChanged(int languageIndex);
+    void saveGoogleEngineRegion(int region);
+    void detectGoogleTextLanguage();
+    void speakGoogleTestText();
+
     void loadShortcut(ShortcutItem *item);
     void updateAcceptButton();
     void acceptCurrentShortcut();
@@ -100,6 +105,7 @@ private:
 
     // Test voice
     QOnlineTranslator *m_yandexTranslator;
+    QOnlineTranslator *m_googleTranslator;
 
 #ifdef WITH_PORTABLE_MODE
     QCheckBox *m_portableCheckbox;

--- a/src/settings/settingsdialog.h
+++ b/src/settings/settingsdialog.h
@@ -98,8 +98,8 @@ private:
     void activateCompactMode();
     void loadSettings();
 
-    void detectTestTextLanguage(QOnlineTranslator *translator, QOnlineTranslator::Engine engine);
-    void speakTestText(QOnlineTranslator *translator, QOnlineTranslator::Engine engine);
+    void detectTestTextLanguage(QOnlineTranslator &translator, QOnlineTranslator::Engine engine);
+    void speakTestText(QOnlineTranslator &translator, QOnlineTranslator::Engine engine);
 
     Ui::SettingsDialog *ui;
 

--- a/src/settings/settingsdialog.h
+++ b/src/settings/settingsdialog.h
@@ -98,6 +98,9 @@ private:
     void activateCompactMode();
     void loadSettings();
 
+    void detectTestTextLanguage(QOnlineTranslator *translator, QOnlineTranslator::Engine engine);
+    void speakTestText(QOnlineTranslator *translator, QOnlineTranslator::Engine engine);
+
     Ui::SettingsDialog *ui;
 
     // Manage platform-dependant autostart

--- a/src/settings/settingsdialog.ui
+++ b/src/settings/settingsdialog.ui
@@ -126,8 +126,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>633</width>
-         <height>604</height>
+         <width>626</width>
+         <height>609</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -1290,6 +1290,62 @@
              </widget>
             </item>
             <item>
+             <widget class="QGroupBox" name="googleSpeechGroupBox">
+              <property name="title">
+               <string>Google</string>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_2">
+               <item row="1" column="1" colspan="2">
+                <layout class="QHBoxLayout" name="googleTestSpeechLayout">
+                 <item>
+                  <widget class="QLineEdit" name="googleTestSpeechEdit">
+                   <property name="toolTip">
+                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Text to test speech&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   </property>
+                   <property name="text">
+                    <string>This is an example of speech synthesis.</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="SpeakButtons" name="googlePlayerButtons" native="true"/>
+                 </item>
+                </layout>
+               </item>
+               <item row="0" column="1">
+                <widget class="QComboBox" name="googleLanguageComboBox">
+                 <property name="currentText">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="0">
+                <widget class="QLabel" name="googleRegionLabel">
+                 <property name="text">
+                  <string>Region:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="2">
+                <widget class="QComboBox" name="googleRegionComboBox">
+                 <item>
+                  <property name="text">
+                   <string>Default region</string>
+                  </property>
+                 </item>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="googleTestSpeechLabel">
+                 <property name="text">
+                  <string>Speech test:</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
              <spacer name="speechPageSpacer">
               <property name="orientation">
                <enum>Qt::Vertical</enum>
@@ -1810,8 +1866,8 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>464</x>
-     <y>409</y>
+     <x>473</x>
+     <y>650</y>
     </hint>
     <hint type="destinationlabel">
      <x>157</x>
@@ -1826,8 +1882,8 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>464</x>
-     <y>409</y>
+     <x>473</x>
+     <y>650</y>
     </hint>
     <hint type="destinationlabel">
      <x>286</x>
@@ -1858,11 +1914,11 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>476</x>
+     <x>280</x>
      <y>63</y>
     </hint>
     <hint type="destinationlabel">
-     <x>723</x>
+     <x>301</x>
      <y>63</y>
     </hint>
    </hints>
@@ -1874,11 +1930,11 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>723</x>
+     <x>301</x>
      <y>63</y>
     </hint>
     <hint type="destinationlabel">
-     <x>476</x>
+     <x>280</x>
      <y>63</y>
     </hint>
    </hints>
@@ -1890,12 +1946,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>483</x>
-     <y>137</y>
+     <x>280</x>
+     <y>51</y>
     </hint>
     <hint type="destinationlabel">
-     <x>732</x>
-     <y>137</y>
+     <x>301</x>
+     <y>51</y>
     </hint>
    </hints>
   </connection>
@@ -1906,12 +1962,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>732</x>
-     <y>137</y>
+     <x>301</x>
+     <y>51</y>
     </hint>
     <hint type="destinationlabel">
-     <x>483</x>
-     <y>137</y>
+     <x>280</x>
+     <y>51</y>
     </hint>
    </hints>
   </connection>
@@ -1922,12 +1978,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>483</x>
-     <y>101</y>
+     <x>280</x>
+     <y>57</y>
     </hint>
     <hint type="destinationlabel">
-     <x>732</x>
-     <y>101</y>
+     <x>301</x>
+     <y>57</y>
     </hint>
    </hints>
   </connection>
@@ -1938,12 +1994,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>732</x>
-     <y>101</y>
+     <x>301</x>
+     <y>57</y>
     </hint>
     <hint type="destinationlabel">
-     <x>483</x>
-     <y>101</y>
+     <x>280</x>
+     <y>57</y>
     </hint>
    </hints>
   </connection>
@@ -1954,12 +2010,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>259</x>
-     <y>38</y>
+     <x>280</x>
+     <y>47</y>
     </hint>
     <hint type="destinationlabel">
-     <x>276</x>
-     <y>36</y>
+     <x>301</x>
+     <y>46</y>
     </hint>
    </hints>
   </connection>
@@ -1970,12 +2026,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>500</x>
-     <y>162</y>
+     <x>301</x>
+     <y>47</y>
     </hint>
     <hint type="destinationlabel">
-     <x>262</x>
-     <y>199</y>
+     <x>243</x>
+     <y>46</y>
     </hint>
    </hints>
   </connection>
@@ -1986,12 +2042,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>500</x>
-     <y>162</y>
+     <x>301</x>
+     <y>47</y>
     </hint>
     <hint type="destinationlabel">
-     <x>262</x>
-     <y>235</y>
+     <x>243</x>
+     <y>45</y>
     </hint>
    </hints>
   </connection>
@@ -2002,12 +2058,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>500</x>
-     <y>162</y>
+     <x>301</x>
+     <y>47</y>
     </hint>
     <hint type="destinationlabel">
-     <x>536</x>
-     <y>235</y>
+     <x>301</x>
+     <y>45</y>
     </hint>
    </hints>
   </connection>
@@ -2018,12 +2074,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>500</x>
-     <y>162</y>
+     <x>301</x>
+     <y>47</y>
     </hint>
     <hint type="destinationlabel">
-     <x>500</x>
-     <y>266</y>
+     <x>301</x>
+     <y>43</y>
     </hint>
    </hints>
   </connection>
@@ -2034,12 +2090,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>500</x>
-     <y>146</y>
+     <x>301</x>
+     <y>185</y>
     </hint>
     <hint type="destinationlabel">
-     <x>500</x>
-     <y>182</y>
+     <x>301</x>
+     <y>214</y>
     </hint>
    </hints>
   </connection>
@@ -2050,12 +2106,12 @@
    <slot>setChecked(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>500</x>
-     <y>146</y>
+     <x>301</x>
+     <y>185</y>
     </hint>
     <hint type="destinationlabel">
-     <x>500</x>
-     <y>182</y>
+     <x>301</x>
+     <y>214</y>
     </hint>
    </hints>
   </connection>
@@ -2066,8 +2122,8 @@
    <slot>onProxyTypeChanged(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>256</x>
-     <y>20</y>
+     <x>283</x>
+     <y>52</y>
     </hint>
     <hint type="destinationlabel">
      <x>399</x>
@@ -2082,8 +2138,8 @@
    <slot>onTrayIconTypeChanged(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>256</x>
-     <y>57</y>
+     <x>301</x>
+     <y>61</y>
     </hint>
     <hint type="destinationlabel">
      <x>399</x>
@@ -2098,8 +2154,8 @@
    <slot>selectCustomTrayIcon()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>282</x>
-     <y>47</y>
+     <x>300</x>
+     <y>58</y>
     </hint>
     <hint type="destinationlabel">
      <x>399</x>
@@ -2114,8 +2170,8 @@
    <slot>setCustomTrayIconPreview(QString)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>256</x>
-     <y>47</y>
+     <x>272</x>
+     <y>58</y>
     </hint>
     <hint type="destinationlabel">
      <x>399</x>
@@ -2130,8 +2186,8 @@
    <slot>saveYandexEngineVoice(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>256</x>
-     <y>42</y>
+     <x>480</x>
+     <y>83</y>
     </hint>
     <hint type="destinationlabel">
      <x>399</x>
@@ -2146,8 +2202,8 @@
    <slot>saveYandexEngineEmotion(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>256</x>
-     <y>38</y>
+     <x>481</x>
+     <y>110</y>
     </hint>
     <hint type="destinationlabel">
      <x>399</x>
@@ -2162,8 +2218,8 @@
    <slot>resetAllShortcuts()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>254</x>
-     <y>20</y>
+     <x>263</x>
+     <y>37</y>
     </hint>
     <hint type="destinationlabel">
      <x>399</x>
@@ -2178,8 +2234,8 @@
    <slot>resetCurrentShortcut()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>288</x>
-     <y>61</y>
+     <x>301</x>
+     <y>74</y>
     </hint>
     <hint type="destinationlabel">
      <x>399</x>
@@ -2194,8 +2250,8 @@
    <slot>acceptCurrentShortcut()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>257</x>
-     <y>61</y>
+     <x>276</x>
+     <y>74</y>
     </hint>
     <hint type="destinationlabel">
      <x>399</x>
@@ -2210,8 +2266,8 @@
    <slot>clearCurrentShortcut()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>272</x>
-     <y>61</y>
+     <x>289</x>
+     <y>74</y>
     </hint>
     <hint type="destinationlabel">
      <x>399</x>
@@ -2226,8 +2282,8 @@
    <slot>updateAcceptButton()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>241</x>
-     <y>61</y>
+     <x>263</x>
+     <y>74</y>
     </hint>
     <hint type="destinationlabel">
      <x>399</x>
@@ -2242,8 +2298,8 @@
    <slot>loadShortcut(ShortcutItem*)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>500</x>
-     <y>195</y>
+     <x>313</x>
+     <y>27</y>
     </hint>
     <hint type="destinationlabel">
      <x>399</x>
@@ -2258,8 +2314,8 @@
    <slot>detectYandexTextLanguage()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>736</x>
-     <y>175</y>
+     <x>808</x>
+     <y>147</y>
     </hint>
     <hint type="destinationlabel">
      <x>399</x>
@@ -2274,8 +2330,8 @@
    <slot>selectOcrLanguagesPath()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>256</x>
-     <y>20</y>
+     <x>301</x>
+     <y>59</y>
     </hint>
     <hint type="destinationlabel">
      <x>399</x>
@@ -2290,8 +2346,8 @@
    <slot>onOcrLanguagesPathChanged(QString)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>256</x>
-     <y>20</y>
+     <x>280</x>
+     <y>59</y>
     </hint>
     <hint type="destinationlabel">
      <x>399</x>
@@ -2306,8 +2362,8 @@
    <slot>onWindowModeChanged(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>402</x>
-     <y>99</y>
+     <x>515</x>
+     <y>122</y>
     </hint>
     <hint type="destinationlabel">
      <x>399</x>
@@ -2322,12 +2378,12 @@
    <slot>addParameter()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>701</x>
-     <y>344</y>
+     <x>268</x>
+     <y>58</y>
     </hint>
     <hint type="destinationlabel">
-     <x>667</x>
-     <y>-19</y>
+     <x>300</x>
+     <y>55</y>
     </hint>
    </hints>
   </connection>
@@ -2338,12 +2394,12 @@
    <slot>removeCurrent()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>701</x>
-     <y>344</y>
+     <x>268</x>
+     <y>60</y>
     </hint>
     <hint type="destinationlabel">
-     <x>667</x>
-     <y>-19</y>
+     <x>300</x>
+     <y>55</y>
     </hint>
    </hints>
   </connection>
@@ -2354,12 +2410,60 @@
    <slot>onTesseractParametersCurrentItemChanged()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>701</x>
-     <y>344</y>
+     <x>300</x>
+     <y>55</y>
     </hint>
     <hint type="destinationlabel">
      <x>667</x>
      <y>-19</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>googleLanguageComboBox</sender>
+   <signal>currentIndexChanged(int)</signal>
+   <receiver>SettingsDialog</receiver>
+   <slot>onGoogleLanguageSelectionChanged(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>473</x>
+     <y>222</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>236</x>
+     <y>655</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>googleRegionComboBox</sender>
+   <signal>currentIndexChanged(int)</signal>
+   <receiver>SettingsDialog</receiver>
+   <slot>saveGoogleEngineRegion(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>639</x>
+     <y>220</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>576</x>
+     <y>657</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>googlePlayerButtons</sender>
+   <signal>playerMediaRequested()</signal>
+   <receiver>SettingsDialog</receiver>
+   <slot>detectGoogleTextLanguage()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>808</x>
+     <y>243</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>424</x>
+     <y>329</y>
     </hint>
    </hints>
   </connection>
@@ -2385,5 +2489,8 @@
   <slot>removeCurrent()</slot>
   <slot>onTesseractParametersCurrentItemChanged()</slot>
   <slot>setCurrentPage(int)</slot>
+  <slot>onGoogleLanguageSelectionChanged(int)</slot>
+  <slot>saveGoogleEngineRegion(int)</slot>
+  <slot>detectGoogleTextLanguage()</slot>
  </slots>
 </ui>

--- a/src/settings/settingsdialog.ui
+++ b/src/settings/settingsdialog.ui
@@ -134,7 +134,7 @@
         <item>
          <widget class="QStackedWidget" name="pagesStackedWidget">
           <property name="currentIndex">
-           <number>0</number>
+           <number>4</number>
           </property>
           <widget class="QWidget" name="generalPage">
            <layout class="QVBoxLayout" name="generalLayout">
@@ -1294,7 +1294,7 @@
               <property name="title">
                <string>Google</string>
               </property>
-              <layout class="QGridLayout" name="gridLayout_2">
+              <layout class="QGridLayout" name="googleSpeechSettingsLayout">
                <item row="1" column="1" colspan="2">
                 <layout class="QHBoxLayout" name="googleTestSpeechLayout">
                  <item>

--- a/src/settings/settingsdialog.ui
+++ b/src/settings/settingsdialog.ui
@@ -134,7 +134,7 @@
         <item>
          <widget class="QStackedWidget" name="pagesStackedWidget">
           <property name="currentIndex">
-           <number>4</number>
+           <number>0</number>
           </property>
           <widget class="QWidget" name="generalPage">
            <layout class="QVBoxLayout" name="generalLayout">

--- a/src/speakbuttons.cpp
+++ b/src/speakbuttons.cpp
@@ -123,6 +123,27 @@ void SpeakButtons::setEmotion(QOnlineTranslator::Engine engine, QOnlineTts::Emot
     }
 }
 
+QMap<QOnlineTranslator::Language, QLocale::Country> SpeakButtons::regions(QOnlineTranslator::Engine engine) const
+{
+    switch (engine) {
+    case QOnlineTranslator::Google:
+        return m_googleRegions;
+    default:
+        return {};
+    }
+}
+
+void SpeakButtons::setRegions(QOnlineTranslator::Engine engine, const QMap<QOnlineTranslator::Language, QLocale::Country> &regions)
+{
+    switch (engine) {
+    case QOnlineTranslator::Google:
+        m_googleRegions = std::move(regions);
+        break;
+    default:
+        break;
+    }
+}
+
 void SpeakButtons::speak(const QString &text, QOnlineTranslator::Language lang, QOnlineTranslator::Engine engine)
 {
     if (text.isEmpty()) {
@@ -131,6 +152,8 @@ void SpeakButtons::speak(const QString &text, QOnlineTranslator::Language lang, 
     }
 
     QOnlineTts onlineTts;
+    onlineTts.setRegions(m_googleRegions);
+
     onlineTts.generateUrls(text, engine, lang, voice(engine), emotion(engine));
     if (onlineTts.error() != QOnlineTts::NoError) {
         QMessageBox::critical(this, tr("Unable to generate URLs for TTS"), onlineTts.errorString());

--- a/src/speakbuttons.cpp
+++ b/src/speakbuttons.cpp
@@ -133,7 +133,7 @@ QMap<QOnlineTranslator::Language, QLocale::Country> SpeakButtons::regions(QOnlin
     }
 }
 
-void SpeakButtons::setRegions(QOnlineTranslator::Engine engine, const QMap<QOnlineTranslator::Language, QLocale::Country> &regions)
+void SpeakButtons::setRegions(QOnlineTranslator::Engine engine, QMap<QOnlineTranslator::Language, QLocale::Country> regions)
 {
     switch (engine) {
     case QOnlineTranslator::Google:

--- a/src/speakbuttons.h
+++ b/src/speakbuttons.h
@@ -55,6 +55,9 @@ public:
     QOnlineTts::Emotion emotion(QOnlineTranslator::Engine engine) const;
     void setEmotion(QOnlineTranslator::Engine engine, QOnlineTts::Emotion emotion);
 
+    QMap<QOnlineTranslator::Language, QLocale::Country> regions(QOnlineTranslator::Engine engine) const;
+    void setRegions(QOnlineTranslator::Engine engine, const QMap<QOnlineTranslator::Language, QLocale::Country> &regions);
+
     void speak(const QString &text, QOnlineTranslator::Language lang, QOnlineTranslator::Engine engine);
     void pauseSpeaking();
     void playPauseSpeaking();
@@ -79,6 +82,7 @@ private:
     QMediaPlayer *m_mediaPlayer = nullptr;
     QOnlineTts::Voice m_yandexVoice = QOnlineTts::NoVoice;
     QOnlineTts::Emotion m_yandexEmotion = QOnlineTts::NoEmotion;
+    QMap<QOnlineTranslator::Language, QLocale::Country> m_googleRegions;
 };
 
 #endif // PLAYERBUTTONS_H

--- a/src/speakbuttons.h
+++ b/src/speakbuttons.h
@@ -56,7 +56,7 @@ public:
     void setEmotion(QOnlineTranslator::Engine engine, QOnlineTts::Emotion emotion);
 
     QMap<QOnlineTranslator::Language, QLocale::Country> regions(QOnlineTranslator::Engine engine) const;
-    void setRegions(QOnlineTranslator::Engine engine, const QMap<QOnlineTranslator::Language, QLocale::Country> &regions);
+    void setRegions(QOnlineTranslator::Engine engine, QMap<QOnlineTranslator::Language, QLocale::Country> regions);
 
     void speak(const QString &text, QOnlineTranslator::Language lang, QOnlineTranslator::Engine engine);
     void pauseSpeaking();


### PR DESCRIPTION
~~There's still a bug actually, and I cannot determine how the hell it got there:~~

~~In `SettingsDialog::loadSettings` TTS region preferences are successfully loaded, but when `SettingsDialog::onGoogleLanguageSelectionChanged` is reached, the country for currently selected language is strangely reset to `QLocale::AnyCountry`.~~
~~So, even if you have set the region for, say, English to United Kingdom previously, when you open settings again it still says "Default region".~~

~~I've left two `qDebugs` in the function in question.~~

Fixed