### PR TITLE
Fix warning generated by clang in OCR module

### DIFF
--- a/src/ocr/ocr.cpp
+++ b/src/ocr/ocr.cpp
@@ -53,10 +53,11 @@ QStringList Ocr::availableLanguages() const
 #endif
     m_tesseract.GetAvailableLanguagesAsVector(&languages);
     availableLanguages.reserve(static_cast<int>(languages.size()));
-    for (const auto &language : languages) {
 #if TESSERACT_MAJOR_VERSION < 5
-        availableLanguages.append(language.string());
+    for (int i = 0; i < languages.size(); ++i) {
+        availableLanguages.append(languages[i].string());
 #else
+    for (const auto &language : languages) {
         availableLanguages.append(QString::fromStdString(language));
 #endif
     }

--- a/src/ocr/ocr.cpp
+++ b/src/ocr/ocr.cpp
@@ -55,7 +55,7 @@ QStringList Ocr::availableLanguages() const
     availableLanguages.reserve(static_cast<int>(languages.size()));
     for (const auto &language : languages) {
 #if TESSERACT_MAJOR_VERSION < 5
-        availableLanguages.append(language);
+        availableLanguages.append(language.string());
 #else
         availableLanguages.append(QString::fromStdString(language));
 #endif

--- a/src/ocr/ocr.cpp
+++ b/src/ocr/ocr.cpp
@@ -52,12 +52,12 @@ QStringList Ocr::availableLanguages() const
     std::vector<std::string> languages;
 #endif
     m_tesseract.GetAvailableLanguagesAsVector(&languages);
-    availableLanguages.reserve(languages.size());
-    for (int i = 0; i < languages.size(); ++i) {
+    availableLanguages.reserve(static_cast<int>(languages.size()));
+    for (const auto &language : languages) {
 #if TESSERACT_MAJOR_VERSION < 5
-        availableLanguages.append(languages[i].string());
+        availableLanguages.append(language);
 #else
-        availableLanguages.append(QString::fromStdString(languages[i]));
+        availableLanguages.append(QString::fromStdString(language));
 #endif
     }
 


### PR DESCRIPTION
Fix two warning generated by newer (?) clang:

1. std::vector::size returns unsigned long, but QList::reserve has an int argument; solution: using static_cast<int>
2. Use range-based for loop instead of old-style for (int i = 0; ...)