### PR TITLE
Correct flags of Hong Kong, Taiwan, and Uyghur for Cantonese, Chinese (Traditional), and Uighur

### DIFF
--- a/data/icons/flags.qrc
+++ b/data/icons/flags.qrc
@@ -12,6 +12,7 @@
         <file alias="br.svg">third-party/circle-flags/flags/br.svg</file>
         <file alias="by.svg">third-party/circle-flags/flags/by.svg</file>
         <file alias="cn.svg">third-party/circle-flags/flags/cn.svg</file>
+        <file alias="cn-xj.svg">third-party/circle-flags/flags/cn-xj.svg</file>
         <file alias="cz.svg">third-party/circle-flags/flags/cz.svg</file>
         <file alias="de.svg">third-party/circle-flags/flags/de.svg</file>
         <file alias="dk.svg">third-party/circle-flags/flags/dk.svg</file>
@@ -20,10 +21,10 @@
         <file alias="es-ga.svg">third-party/circle-flags/flags/es-ga.svg</file>
         <file alias="es-pv.svg">third-party/circle-flags/flags/es-pv.svg</file>
         <file alias="es.svg">third-party/circle-flags/flags/es.svg</file>
-        <file alias="esperanto.svg">third-party/circle-flags/flags/esperanto.svg</file>
+        <file alias="eo.svg">third-party/circle-flags/flags/language/eo.svg</file>
         <file alias="et.svg">third-party/circle-flags/flags/et.svg</file>
         <file alias="fi.svg">third-party/circle-flags/flags/fi.svg</file>
-        <file alias="fiction/klingon.svg">third-party/circle-flags/flags/fiction/klingon.svg</file>
+        <file alias="fictional/klingon.svg">third-party/circle-flags/flags/fictional/klingon.svg</file>
         <file alias="fj.svg">third-party/circle-flags/flags/fj.svg</file>
         <file alias="fr.svg">third-party/circle-flags/flags/fr.svg</file>
         <file alias="gb-sct.svg">third-party/circle-flags/flags/gb-sct.svg</file>
@@ -31,6 +32,7 @@
         <file alias="gb.svg">third-party/circle-flags/flags/gb.svg</file>
         <file alias="ge.svg">third-party/circle-flags/flags/ge.svg</file>
         <file alias="gr.svg">third-party/circle-flags/flags/gr.svg</file>
+        <file alias="hk.svg">third-party/circle-flags/flags/hk.svg</file>
         <file alias="hr.svg">third-party/circle-flags/flags/hr.svg</file>
         <file alias="ht.svg">third-party/circle-flags/flags/ht.svg</file>
         <file alias="hu.svg">third-party/circle-flags/flags/hu.svg</file>

--- a/src/languagebuttonswidget.cpp
+++ b/src/languagebuttonswidget.cpp
@@ -185,9 +185,9 @@ QIcon LanguageButtonsWidget::countryIcon(QOnlineTranslator::Language lang)
     case QOnlineTranslator::SimplifiedChinese:
         return QIcon(":/icons/flags/cn.svg");
     case QOnlineTranslator::TraditionalChinese:
-        return QIcon(":/icon/flags/tw.svg");
+        return QIcon(":/icons/flags/tw.svg");
     case QOnlineTranslator::Uighur:
-        return QIcon(":/icon/flags/cn-xj.svg");
+        return QIcon(":/icons/flags/cn-xj.svg");
     case QOnlineTranslator::Croatian:
         return QIcon(":/icons/flags/hr.svg");
     case QOnlineTranslator::Czech:

--- a/src/languagebuttonswidget.cpp
+++ b/src/languagebuttonswidget.cpp
@@ -180,11 +180,14 @@ QIcon LanguageButtonsWidget::countryIcon(QOnlineTranslator::Language lang)
     case QOnlineTranslator::Catalan:
         return QIcon(":/icons/flags/ad.svg");
     case QOnlineTranslator::Cantonese:
+        return QIcon(":/icons/flags/hk.svg");
     case QOnlineTranslator::Hmong:
     case QOnlineTranslator::SimplifiedChinese:
-    case QOnlineTranslator::TraditionalChinese:
-    case QOnlineTranslator::Uighur:
         return QIcon(":/icons/flags/cn.svg");
+    case QOnlineTranslator::TraditionalChinese:
+        return QIcon(":/icon/flags/tw.svg");
+    case QOnlineTranslator::Uighur:
+        return QIcon(":/icon/flags/cn-xj.svg");
     case QOnlineTranslator::Croatian:
         return QIcon(":/icons/flags/hr.svg");
     case QOnlineTranslator::Czech:
@@ -197,7 +200,7 @@ QIcon LanguageButtonsWidget::countryIcon(QOnlineTranslator::Language lang)
     case QOnlineTranslator::English:
         return QIcon(":/icons/flags/gb.svg");
     case QOnlineTranslator::Esperanto:
-        return QIcon(":/icons/flags/esperanto.svg");
+        return QIcon(":/icons/flags/eo.svg");
     case QOnlineTranslator::Estonian:
         return QIcon(":/icons/flags/ee.svg");
     case QOnlineTranslator::Fijian:
@@ -262,7 +265,7 @@ QIcon LanguageButtonsWidget::countryIcon(QOnlineTranslator::Language lang)
         return QIcon(":/icons/flags/rw.svg");
     case QOnlineTranslator::Klingon:
     case QOnlineTranslator::KlingonPlqaD:
-        return QIcon(":/icons/flags/fiction/klingon.svg");
+        return QIcon(":/icons/flags/fictional/klingon.svg");
     case QOnlineTranslator::Korean:
         return QIcon(":/icons/flags/kr.svg");
     case QOnlineTranslator::Kurdish:


### PR DESCRIPTION
As in title.
https://github.com/HatScripts/circle-flags.git was updated to 2.4.1 since uyghur flag is only available after 2.4.0.