### PR TITLE
Read settings from application directory when building in portable mode

### DIFF
--- a/src/settings/appsettings.h
+++ b/src/settings/appsettings.h
@@ -24,6 +24,7 @@
 
 #include <QLocale>
 #include <QNetworkProxy>
+#include <QCoreApplication>
 
 class QTranslator;
 class QSettings;
@@ -385,7 +386,7 @@ private:
     static QTranslator s_appTranslator;
     static QTranslator s_qtTranslator; // Qt library translations
 #ifdef WITH_PORTABLE_MODE
-    static inline const QString s_portableConfigName = QStringLiteral("settings.ini");
+    static inline const QString s_portableConfigName = QCoreApplication::applicationDirPath() + "/" + QStringLiteral("settings.ini");
 #endif
 
     QSettings *m_settings;

--- a/src/settings/appsettings.h
+++ b/src/settings/appsettings.h
@@ -22,9 +22,9 @@
 
 #include "qonlinetts.h"
 
+#include <QCoreApplication>
 #include <QLocale>
 #include <QNetworkProxy>
-#include <QCoreApplication>
 
 class QTranslator;
 class QSettings;

--- a/src/settings/settingsdialog.cpp
+++ b/src/settings/settingsdialog.cpp
@@ -60,7 +60,7 @@ SettingsDialog::SettingsDialog(MainWindow *parent)
     ui->versionLabel->setText(QCoreApplication::applicationVersion());
 
 #ifdef WITH_PORTABLE_MODE
-    m_portableCheckbox->setToolTip(tr("Use %1 from the application folder to store settings").arg(AppSettings::portableConfigName()));
+    m_portableCheckbox->setToolTip(tr("Use %1 to store settings").arg(AppSettings::portableConfigName()));
     qobject_cast<QFormLayout *>(ui->generalGroupBox->layout())->addRow(m_portableCheckbox);
 #endif
 


### PR DESCRIPTION
Closes #556 