### PR TITLE
Save audio and text to files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,10 @@ add_executable(${PROJECT_NAME}
     src/settings/shortcutsmodel/shortcutsview.cpp
     src/settings/tesseractparameterstablewidget.cpp
     src/settings/autostartmanager/abstractautostartmanager.cpp
+    src/fileutil/fileutil.h
+    src/fileutil/fileutil.cpp
+    src/fileutil/showmsg.h
+    src/fileutil/showmsg.cpp    
     src/sourcetextedit.cpp
     src/speakbuttons.cpp
     src/speakbuttons.ui

--- a/src/fileutil/fileutil.cpp
+++ b/src/fileutil/fileutil.cpp
@@ -1,0 +1,395 @@
+#include "fileutil.h"
+
+FileUtil::FileUtil(): QObject(0), msg(new ShowMsg) {
+
+}
+
+/**
+ * Create a directory for a given name.
+ *
+ * @brief WriteFile::writeDir
+ */
+bool FileUtil::writeDir()
+{
+    QDir dir = QDir::root(); // Root is equal = "/" or "C:" to Windows
+    if (dir.mkdir(getWorkSpace())) {
+//        qWarning("%s directory, Created Sucessfully...", getWorkspace().toStdString().c_str());
+        return true;
+    }
+    return false;
+}
+
+/**
+ * Valide if dir really exist.
+ *
+ * @brief WriteFile::validDir
+ * @return true or false
+ */
+bool FileUtil::validDir()
+{
+    QDir dir = QDir::root();
+    if (dir.cd(getWorkSpace())) {
+        return true;
+    }
+    return false;
+}
+/**
+ * Valid if path to workspace is
+ * a name allowed...
+ * @brief WriteFile::validStrDir
+ * @return
+ */
+bool FileUtil::validStrDir(QString &str){
+    /**
+     * Means:
+     * Treat: À to ÿ, à to ÿ, A to Z, a to z, 0 to 9
+     * Treat: ., -, _, /
+     * '^[' to start, and ']+$' to stop treatments.
+     * @brief rx3
+     */
+    QRegExp mrgx("^[A-Za-z0-9\\.\\-\\_\\/]+$");
+    if(!str.contains(mrgx)){
+        return false;
+    }
+    return true;
+}
+
+
+/**
+ * Validates that the file name does not
+ * contain incompatible characters.
+ * @brief WriteFile::validStrFile
+ * @return
+ */
+bool FileUtil::validStrFile(QString &str)
+{
+    /**
+     * All characters different of than those below
+     * will not be allowed.
+     * Treat: A to Z, a to z, 0 to 9
+     * Treat: ., -, _, /
+     * '^[' to start, and ']+$' to stop treatments.
+     * @brief rx3
+     */
+    QRegExp mrgx("^[A-Za-z0-9\\.\\-\\_]+$");
+    QRegExp reg_txt("*.txt");
+    reg_txt.setPatternSyntax(QRegExp::Wildcard);
+    QRegExp reg_md("*.md");
+    reg_md.setPatternSyntax(QRegExp::Wildcard);
+    QRegExp reg_log("*.log");
+    reg_log.setPatternSyntax(QRegExp::Wildcard);
+
+    if(!(reg_txt.exactMatch(str)) & !(reg_md.exactMatch(str)) & !(reg_log.exactMatch(str)))
+        return false;
+
+    if(!str.contains(mrgx)) return false;
+//    qWarning("Past in First test....");
+
+    if(str.count('.') > 1) return false;
+//    qWarning("Past in Second test....");
+
+    QString str_ext = str.split(".").at(1).toLower();//get extension
+    //
+    if(str_ext.size() > 3) return false;
+//    qWarning("Past in Third test....");
+
+    if(!(str_ext == "log") && !(str_ext == "txt") && !(str_ext == "md")) {
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * Validates the file name and extension, to check
+ * for wrong characters. And also if the extension
+ * is incompatible.
+ * @brief WriteFile::validStrAudioFileName
+ * @return true or false
+ */
+bool FileUtil::validStrAudioFileName(QString &str)
+{
+    /**
+     * All characters different of than those below
+     * will not be allowed.
+     * Treat: A to Z, a to z, 0 to 9
+     * Treat: ., -, _, /
+     * '^[' to start, and ']+$' to stop treatments.
+     * @brief rx3
+     */
+    QRegExp mrgx("^[A-Za-z0-9\\.\\-\\_]+$");
+    QRegExp reg_mp3("*.mp3");
+    reg_mp3.setPatternSyntax(QRegExp::Wildcard);
+
+    if(!reg_mp3.exactMatch(str))
+        return false;
+
+    if(!str.contains(mrgx)) return false;
+    if(str.count('.') > 1) return false;
+
+    QString str_ext = str.split(".").at(1).toLower();//get extension
+    //
+    if(str_ext.size() > 3) return false;
+
+    if(!(str_ext == "mp3")) {
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * Valid if file exist for the given name.
+ * @brief FileUtil::validFile
+ * @return
+ */
+bool FileUtil::validFile()
+{
+    QString path_file = getWorkSpace() + getTextFile()+ getTextFileExt();
+    QFile file(path_file);
+
+    if(file.exists())
+        return true;
+    return false;
+}
+
+/**
+ * getAudiofile()
+ * @brief FileUtil::getAudioFile()
+ * @return
+ */
+QString FileUtil::getAudioFile() const
+{
+    return audioFile;
+}
+
+/**
+ * setAudiofile(const QString &newAudiofile)
+ * audioFile = path + newAudiofile
+ * @brief FileUtil::setAudioFile
+ * @param newAudioFile
+ */
+void FileUtil::setAudioFile(const QString &newAudiofile)
+{
+    //get file without extension
+    QString str_file = newAudiofile.split(QLatin1Char('.')).at(0);
+
+    //get extension
+    QString str_ext  = "." +newAudiofile.split(QLatin1Char('.')).at(1);
+    setAudioExt(str_ext);
+
+    //Full name with  + workspace + filename
+    QString pathfile = getWorkSpace()+str_file;
+
+    audioFile = pathfile;
+}
+
+/**
+ * getFiletext()
+ * @brief FileUtil::getTextFile()
+ * @return
+ */
+QString FileUtil::getTextFile() const
+{
+    return textFile;
+}
+
+/**
+ * setTextFile(const QString &newFiletext)
+ * setFullflpath() = path + filetext
+ * @brief FileUtil::setTextFile(const QString &newFiletext)
+ * @param QString &newFiletext
+ */
+void FileUtil::setTextFile(const QString &newFiletext)
+{
+    QDateTime dt_time(QDateTime::currentDateTime());
+    QString format = "dd-MM-yyyy-HH";
+    QString date_to_file  = dt_time.toString(format);
+
+    //get file without extension
+    QString str_file = newFiletext.split(QLatin1Char('.')).at(0);
+
+    //get extension
+    QString str_ext  = "." +newFiletext.split(QLatin1Char('.')).at(1);
+    setTextFileExt(str_ext);
+
+   //Full name with  + workspace + filename + datepart
+    QString pathfile = getWorkSpace()+str_file+"-"+date_to_file;
+
+    textFile = pathfile;
+}
+
+/**
+ * getWorkspace()
+ * Defined in the geral menu.
+ * @brief FileUtil::getWorkspace
+ * @return
+ */
+QString FileUtil::getWorkSpace() const
+{
+    return workSpace;
+}
+
+
+/**
+ * setWorspace(const QString &newWorkspace)
+ * get it from config file.
+ * @brief FileUtil::setWorkSpace
+ * @param newWorkspace
+ */
+void FileUtil::setWorkSpace(const QString &newWorkspace)
+{
+    workSpace = newWorkspace.endsWith('/')? newWorkspace : newWorkspace+'/';
+}
+
+QString FileUtil::getTmp_audiofn() const
+{
+    return tmp_audiofn;
+}
+
+void FileUtil::setTmp_audiofn(const QString &newTmp_audiofn)
+{
+    tmp_audiofn = newTmp_audiofn;
+}
+
+QString FileUtil::getTmp_textfn() const
+{
+    return tmp_textfn;
+}
+
+void FileUtil::setTmp_textfn(const QString &newTmp_textfn)
+{
+    tmp_textfn = newTmp_textfn;
+}
+
+ShowMsg *FileUtil::getMsg() const
+{
+    return msg;
+}
+
+void FileUtil::setMsg(ShowMsg *newMsg)
+{
+    msg = newMsg;
+}
+
+QString FileUtil::getAudioExt() const
+{
+    return audioExt;
+}
+
+void FileUtil::setAudioExt(const QString &newAudioExt)
+{
+    audioExt = newAudioExt;
+}
+
+QString FileUtil::getTextFileExt() const
+{
+    return textFileExt;
+}
+
+void FileUtil::setTextFileExt(const QString &newTextFileExt)
+{
+    textFileExt = newTextFileExt;
+}
+
+
+/**
+ * Method to write to txt file.
+ * @brief FileUtil::writeTxtFile
+ * @param text
+ */
+void FileUtil::writeTxtFile(const QString &text) {
+    //
+    QDateTime dt_time(QDateTime::currentDateTime());
+
+    QString format1 = "dd-MM-yyyy HH:mm:ss";
+    QString date_formated = dt_time.toString(format1);
+
+    QString file_path = getTextFile() + getTextFileExt();
+
+   // qDebug() << "Actual file path: " << file_path;
+
+    QFile localFile(file_path);
+
+    if (localFile.open(QIODevice::WriteOnly | QIODevice::Text | QIODevice::Append)) {
+        QTextStream out(&localFile);
+        out << "\n";
+        out << "---\n";
+        out << "### Data: " << date_formated << "\n";
+        out <<"\n" << text << "\n";
+        out << "\n---\n";
+        localFile.close();
+
+        if(localFile.exists() && localFile.size() > text.size() ){
+            msg->setMsgType(INFO);
+            msg->setMsg("File Saved Successfully...");
+            setMsg(msg);
+//            qDebug() << msg->getMsg();
+        }
+    } else {
+        msg->setMsgType(ERROR);
+        QString error_msg = "Error, Unable to write data to file: " + file_path;
+        msg->setMsg(error_msg);
+        setMsg(msg);
+//        qDebug() << msg->getMsg();
+    }
+
+}
+
+/**
+ * Method to write to audio file
+ * @brief FileUtil::writeMp3File
+ * @param strurl
+ * @param oper
+ * @param seq
+ */
+void FileUtil::writeMp3File(const QString &strurl, const QString &oper, int seq)
+{
+    QString m_seq = seq ==0? "":"-"+QString::number(seq);
+    const QString str_file =
+        getAudioFile() +   //get audiofile name path + name without extension
+        "-"  +             //Just to separator
+        oper +             //sigla to lang
+        m_seq +            //File sequencia
+        getAudioExt();     //get extension with point.
+    //
+    QFile localFile(str_file);
+
+    QNetworkReply *response = manager.get(QNetworkRequest(QUrl(strurl)));
+    QEventLoop event;
+    connect(response, SIGNAL(finished()), &event, SLOT(quit()));
+    event.exec();
+
+    const QByteArray sdata = response->readAll();
+    //
+    if(sdata.isEmpty()){
+        msg->setMsgType(ERROR);
+        QString error = "Error, Unable to get data from url: " + strurl;
+        msg->setMsg(error);
+        setMsg(msg);
+//        qDebug() << msg->getMsg();
+        return;
+    }
+
+    if (!localFile.open(QIODevice::WriteOnly)){
+        msg->setMsgType(ERROR);
+        QString error = "Error Opening file: " + str_file;
+        msg->setMsg(error);
+        setMsg(msg);
+//        qDebug() << msg->getMsg();
+        return;
+    }
+
+    localFile.write(sdata);
+    localFile.close();
+
+    if(localFile.exists() && localFile.size() == sdata.size()){
+        msg->setMsgType(INFO);
+        msg->setMsg("Download Sucessfully...");
+        setMsg(msg);
+//        qDebug() << msg->getMsg();
+    }
+}
+
+
+

--- a/src/fileutil/fileutil.h
+++ b/src/fileutil/fileutil.h
@@ -1,0 +1,69 @@
+#ifndef FILEUTIL_H
+#define FILEUTIL_H
+
+#include <QtCore/QCoreApplication>
+#include<QTextStream>
+#include <QtNetwork/QNetworkAccessManager>
+#include <QtNetwork/QNetworkReply>
+#include <QFile>
+#include <QDir>
+#include <QString>
+#include <QDateTime>
+#include <QObject>
+#include "showmsg.h"
+#include "qonlinetranslator.h"
+#include "qonlinetts.h"
+
+class ShowMsg;
+
+class FileUtil : public QObject
+{
+    Q_OBJECT
+public:
+    explicit FileUtil();
+    bool writeDir();
+    bool validDir();
+    bool validStrDir(QString &str);
+    bool validStrFile(QString &str);
+    bool validStrAudioFileName(QString &str);
+    bool validFile();
+    void writeTxtFile(const QString &text);
+    void writeMp3File(const QString &strurl, const QString &oper, int seq);
+
+    QString getAudioFile() const;
+    void setAudioFile(const QString &newAudiofile);
+    QString getTextFile() const;
+    void setTextFile(const QString &newFiletext);
+    QString getWorkSpace() const;
+    void setWorkSpace(const QString &newWorkspace);
+
+    QString getTmp_audiofn() const;
+    void setTmp_audiofn(const QString &newTmp_audiofn);
+
+    QString getTmp_textfn() const;
+    void setTmp_textfn(const QString &newTmp_textfn);
+
+    ShowMsg *msg;
+    ShowMsg *getMsg() const;
+    void setMsg(ShowMsg *newMsg);
+
+    QString getAudioExt() const;
+    void setAudioExt(const QString &newAudioExt);
+
+    QString getTextFileExt() const;
+    void setTextFileExt(const QString &newTextFileExt);
+
+private:
+    QString workSpace;
+    QString audioFile;
+    QString audioExt;
+    QString textFile;
+    QString textFileExt;
+    QString tmp_audiofn;
+    QString tmp_textfn;
+
+    QNetworkAccessManager manager;
+
+};
+
+#endif // FILEUTIL_H

--- a/src/fileutil/showmsg.cpp
+++ b/src/fileutil/showmsg.cpp
@@ -1,0 +1,58 @@
+
+#include "showmsg.h"
+
+ShowMsg::ShowMsg() {
+}
+
+ShowMsg::~ShowMsg() {
+}
+
+/**
+ * Show a type of message.
+ * E.G. ShowGuiMessage("info", "Message", "Everything is AlRight!!");
+ * @param msgtype
+ * @param msgtitle
+ * @param message
+ */
+void ShowMsg::ShowGuiMessage(QString msgtype, QString msgtitle, QString message) {
+
+    if (msgtype == INFO) {
+        msgBox.setIcon(QMessageBox::Information);
+        msgBox.setWindowTitle(msgtitle);
+        msgBox.setText(message);
+        //
+        msgBox.exec();
+    } else if (msgtype == WARN) {
+        msgBox.setIcon(QMessageBox::Warning);
+        msgBox.setWindowTitle(msgtitle);
+        msgBox.setText(message);
+        //
+        msgBox.exec();
+    } else if (msgtype == ERROR) {
+        msgBox.setIcon(QMessageBox::Critical);
+        msgBox.setWindowTitle(msgtitle);
+        msgBox.setText(message);
+        //
+        msgBox.exec();
+    }
+}
+
+QString ShowMsg::getMsg() const
+{
+    return msg;
+}
+
+void ShowMsg::setMsg(const QString &newMsg)
+{
+    msg = newMsg;
+}
+
+QString ShowMsg::getMsgType() const
+{
+    return msgType;
+}
+
+void ShowMsg::setMsgType(const QString &newMsgType)
+{
+    msgType = newMsgType;
+}

--- a/src/fileutil/showmsg.h
+++ b/src/fileutil/showmsg.h
@@ -1,0 +1,43 @@
+/* 
+ * File:   ShowMsg.h
+ * Author: batista
+ *
+ * Created on 8 de Março de 2013, 20:45
+ */
+
+#ifndef SHOWMSG_H
+#define	SHOWMSG_H
+#include <QMessageBox>
+#include <QtGui>
+#include <QObject>
+#include <QDebug>
+#include <QString>
+
+#define INFO        "info"
+#define WARN        "warn"
+#define ERROR       "error"
+
+class QMessageBox;
+
+class ShowMsg {
+public:
+    ShowMsg();
+    virtual ~ShowMsg();
+    //
+    void ShowGuiMessage(QString msgtype, QString msgtitle, QString message);
+
+    QString getMsg() const;
+    void setMsg(const QString &newMsg);
+
+    QString getMsgType() const;
+    void setMsgType(const QString &newMsgType);
+
+private:
+    QMessageBox msgBox;
+    QString msg;
+    QString msgType;
+
+};
+
+#endif	/* SHOWMSG_H */
+

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -77,6 +77,8 @@ MainWindow::MainWindow(QWidget *parent)
     , m_orientationWatcher(new ScreenWatcher(this))
     , m_screenGrabber(AbstractScreenGrabber::createScreenGrabber(this))
     , m_snippingArea(new SnippingArea(this))
+    , m_fileutil(new FileUtil())
+    , m_msg(new ShowMsg())
 {
     ui->setupUi(this);
 
@@ -485,6 +487,114 @@ void MainWindow::forceTranslationAutodetect()
         m_listenForContentChanges = before;
     }
 }
+
+//Mine's events start here
+/**
+ * To write Text File from the sourcer
+ * Text to tranlate...
+ * @brief MainWindow::runWriteToTextFileInSr
+ */
+void MainWindow::runWriteToTextFileInSr()
+{
+    QString source_text = ui->sourceEdit->toSourceText();
+    m_fileutil->writeTxtFile(source_text);
+
+    if(m_fileutil->getMsg()->getMsgType() == INFO){
+        m_msg->ShowGuiMessage(INFO,tr("Information"), tr(m_fileutil->getMsg()->getMsg().toStdString().c_str()));
+    }else{
+        m_msg->ShowGuiMessage(ERROR,tr("Error"), tr(m_fileutil->getMsg()->getMsg().toStdString().c_str()));
+    }
+}
+
+/**
+ * To write Text File from the translate
+ * Text tranlated...
+ * @brief MainWindow::runWriteToTextFileInTr
+ */
+void MainWindow::runWriteToTextFileInTr()
+{
+    QString source_text = ui->translationEdit->toPlainText();
+
+    m_fileutil->writeTxtFile(source_text);
+
+    if(m_fileutil->getMsg()->getMsgType() == INFO){
+        m_msg->ShowGuiMessage(INFO,tr("Information"), tr(m_fileutil->getMsg()->getMsg().toStdString().c_str()));
+    }else{
+        m_msg->ShowGuiMessage(ERROR,tr("Error"), tr(m_fileutil->getMsg()->getMsg().toStdString().c_str()));
+    }
+}
+
+/**
+ * Write audio to translate
+ * @brief MainWindow::runTTsAudioFileInSr
+ */
+void MainWindow::runTTsAudioFileInSr()
+{
+    QList<QString> m_url_audio;
+    QString lang = QOnlineTranslator::languageCode(ui->sourceLanguagesWidget->checkedLanguage());
+
+    m_url_audio = ui->sourceSpeakButtons->getUrlToFileMp3(ui->sourceEdit->toSourceText(), ui->sourceLanguagesWidget->checkedLanguage(), currentEngine());
+    //
+    if(!m_url_audio.empty()){
+        int seq=0;
+        if(m_url_audio.size() > 1){
+            foreach (QString m_url, m_url_audio) {
+                seq++;
+                m_fileutil->writeMp3File(m_url,lang ,seq);
+                if(m_fileutil->getMsg()->getMsgType() == INFO){
+                    m_msg->ShowGuiMessage(INFO,tr("Information"), tr(m_fileutil->getMsg()->getMsg().toStdString().c_str()));
+                }else{
+                    m_msg->ShowGuiMessage(ERROR,tr("Error"), tr(m_fileutil->getMsg()->getMsg().toStdString().c_str()));
+                }
+            }
+        }else{
+            m_fileutil->writeMp3File(m_url_audio.at(seq),lang ,seq);
+            if(m_fileutil->getMsg()->getMsgType() == INFO){
+                m_msg->ShowGuiMessage(INFO,tr("Information"), tr(m_fileutil->getMsg()->getMsg().toStdString().c_str()));
+            }else{
+                m_msg->ShowGuiMessage(ERROR,tr("Error"), tr(m_fileutil->getMsg()->getMsg().toStdString().c_str()));
+            }
+        }
+    }
+
+}
+
+/**
+ * Write audio translated...
+ * @brief MainWindow::runTTsAudioFileInTr
+ */
+void MainWindow::runTTsAudioFileInTr()
+{
+    QList<QString> m_url_audio;
+    QString lang = QOnlineTranslator::languageCode(ui->translationLanguagesWidget->checkedLanguage());
+
+    m_url_audio = ui->sourceSpeakButtons->getUrlToFileMp3(ui->translationEdit->translation(), ui->translationEdit->translationLanguage(), currentEngine());
+    //
+    if(!m_url_audio.empty()){
+        int seq=0;
+        if(m_url_audio.size() > 1){
+            foreach (QString m_url, m_url_audio) {
+                seq++;
+                m_fileutil->writeMp3File(m_url,lang ,seq);
+                if(m_fileutil->getMsg()->getMsgType() == INFO){
+                    m_msg->ShowGuiMessage(INFO,tr("Information"), tr(m_fileutil->getMsg()->getMsg().toStdString().c_str()));
+                }else{
+                    m_msg->ShowGuiMessage(ERROR,tr("Error"), tr(m_fileutil->getMsg()->getMsg().toStdString().c_str()));
+                }
+            }
+        }else{
+            m_fileutil->writeMp3File(m_url_audio.at(seq),lang ,seq);
+            if(m_fileutil->getMsg()->getMsgType() == INFO){
+                m_msg->ShowGuiMessage(INFO,tr("Information"), tr(m_fileutil->getMsg()->getMsg().toStdString().c_str()));
+            }else{
+                m_msg->ShowGuiMessage(ERROR,tr("Error"), tr(m_fileutil->getMsg()->getMsg().toStdString().c_str()));
+            }
+        }
+    }
+}
+
+//Mine's events end here
+
 
 void MainWindow::minimize()
 {
@@ -1045,6 +1155,12 @@ void MainWindow::loadAppSettings()
     ui->swapButton->setShortcut(settings.swapShortcut());
     ui->copyTranslationButton->setShortcut(settings.copyTranslationShortcut());
     m_closeWindowsShortcut->setKey(settings.closeWindowShortcut());
+
+    //Added batista
+    //Set data to work with Files and WorkSpace
+    m_fileutil->setWorkSpace(settings.getCustWorkSpace());
+    m_fileutil->setTextFile(settings.getCustFileName());
+    m_fileutil->setAudioFile(settings.getCustAudioFileName());
 }
 
 // Toggle language logic

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -40,6 +40,8 @@ class QTaskbarControl;
 class QComboBox;
 class QShortcut;
 class QToolButton;
+class FileUtil;
+class ShowMsg;
 
 namespace Ui
 {
@@ -121,6 +123,13 @@ private slots:
     void showTranslationWindow();
     void copyTranslationToClipboard();
 
+    //Added batista
+    void runWriteToTextFileInSr();
+    void runWriteToTextFileInTr();
+    void runTTsAudioFileInSr();
+    void runTTsAudioFileInTr();
+    //End Added
+
     void forceSourceAutodetect();
     void forceTranslationAutodetect();
 
@@ -198,6 +207,10 @@ private:
     QOnlineTranslator::Language m_secondaryLanguage;
 
     AppSettings::WindowMode m_windowMode;
+
+    //Added batista
+    FileUtil * m_fileutil;
+    ShowMsg * m_msg;
 
     bool m_forceSourceAutodetect;
     bool m_forceTranslationAutodetect;

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -71,6 +71,34 @@
           </property>
          </widget>
         </item>
+        <item>
+         <widget class="QToolButton" name="writeTTSAudioTBsr">
+          <property name="toolTip">
+           <string>Write TTS Audio to File...</string>
+          </property>
+          <property name="text">
+           <string>...</string>
+          </property>
+          <property name="icon">
+           <iconset theme="audio-x-generic">
+            <normaloff>.</normaloff>.</iconset>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QToolButton" name="writeTextFileTBsr">
+          <property name="toolTip">
+           <string>Write text to File...</string>
+          </property>
+          <property name="text">
+           <string>...</string>
+          </property>
+          <property name="icon">
+           <iconset theme="document-save">
+            <normaloff>.</normaloff>.</iconset>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
       <item row="4" column="1">
@@ -273,6 +301,34 @@
           </property>
           <property name="icon">
            <iconset theme="transform-crop">
+            <normaloff>.</normaloff>.</iconset>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QToolButton" name="writeTTSAudioTBtr">
+          <property name="toolTip">
+           <string>Write TTS Audio to File...</string>
+          </property>
+          <property name="text">
+           <string>...</string>
+          </property>
+          <property name="icon">
+           <iconset theme="audio-x-generic">
+            <normaloff>.</normaloff>.</iconset>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QToolButton" name="writeTextFileTBtr">
+          <property name="toolTip">
+           <string>Write Text to File...</string>
+          </property>
+          <property name="text">
+           <string>...</string>
+          </property>
+          <property name="icon">
+           <iconset theme="document-save">
             <normaloff>.</normaloff>.</iconset>
           </property>
          </widget>
@@ -622,6 +678,70 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>writeTextFileTBsr</sender>
+   <signal>clicked()</signal>
+   <receiver>MainWindow</receiver>
+   <slot>runWriteToTextFileInSr()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>235</x>
+     <y>183</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>324</x>
+     <y>102</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>writeTextFileTBtr</sender>
+   <signal>clicked()</signal>
+   <receiver>MainWindow</receiver>
+   <slot>runWriteToTextFileInTr()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>596</x>
+     <y>183</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>324</x>
+     <y>102</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>writeTTSAudioTBsr</sender>
+   <signal>clicked()</signal>
+   <receiver>MainWindow</receiver>
+   <slot>runTTsAudioFileInSr()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>205</x>
+     <y>183</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>324</x>
+     <y>102</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>writeTTSAudioTBtr</sender>
+   <signal>clicked()</signal>
+   <receiver>MainWindow</receiver>
+   <slot>runTTsAudioFileInTr()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>566</x>
+     <y>183</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>324</x>
+     <y>102</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
  <slots>
   <slot>swapLanguages()</slot>
@@ -635,5 +755,9 @@
   <slot>delayedRecognizeScreenArea()</slot>
   <slot>delayedTranslateScreenArea()</slot>
   <slot>markContentAsChanged()</slot>
+  <slot>runWriteToTextFileInSr()</slot>
+  <slot>runWriteToTextFileInTr()</slot>
+  <slot>runTTsAudioFileInSr()</slot>
+  <slot>runTTsAudioFileInTr()</slot>
  </slots>
 </ui>

--- a/src/settings/appsettings.cpp
+++ b/src/settings/appsettings.cpp
@@ -197,6 +197,102 @@ bool AppSettings::defaultAutostartEnabled()
     return false;
 }
 
+void AppSettings::setEnableCustWorkSpace(bool enable)
+{
+    m_settings->setValue(QStringLiteral("EnableCustWorkSpace"), enable);
+}
+
+bool AppSettings::isEnableCustWorkSpace() const
+{
+    return m_settings->value(QStringLiteral("EnableCustWorkSpace"), defaultEnableCustWorkSpace()).toBool();
+}
+
+bool AppSettings::defaultEnableCustWorkSpace()
+{
+    return false;
+}
+
+//My updates
+QString AppSettings::getCustWorkSpace() const
+{
+    return m_settings->value("WorkSpace", defaultCustWorkSpace()).toString();
+}
+
+void AppSettings::setCustWorkSpace(QString path)
+{
+    m_settings->setValue("WorkSpace",path);//or path
+}
+
+QString AppSettings::defaultCustWorkSpace()
+{
+#ifdef Q_OS_LINUX
+    return ".crow-translate";
+#endif
+    return "C:/.Crow";
+}
+
+void AppSettings::setEnableCustFileName(bool enable)
+{
+    m_settings->setValue(QStringLiteral("EnableCustFileName"), enable);
+}
+
+bool AppSettings::isEnableCustFileName() const
+{
+    return m_settings->value(QStringLiteral("EnableCustFileName"), defaultEnableCustFileName()).toBool();
+}
+
+bool AppSettings::defaultEnableCustFileName()
+{
+    return false;
+}
+
+QString AppSettings::getCustFileName() const
+{
+    return m_settings->value("FileName", defaultCustFileName()).toString();
+}
+
+void AppSettings::setCustFileName(QString filename)
+{
+    m_settings->setValue("FileName", filename);
+}
+
+QString AppSettings::defaultCustFileName()
+{
+    return "Crow-translate.txt";
+}
+
+void AppSettings::setEnableCustAudioFileName(bool enable)
+{
+    m_settings->setValue(QStringLiteral("EnableCustAudioFileName"), enable);
+}
+
+bool AppSettings::isEnableCustAudioFileName() const
+{
+    return m_settings->value(QStringLiteral("EnableCustAudioFileName"), defaultEnableCustAudioFile()).toBool();
+}
+
+bool AppSettings::defaultEnableCustAudioFile()
+{
+    return false;
+}
+
+QString AppSettings::getCustAudioFileName() const
+{
+    return m_settings->value("AudioName", defaultCustAudioFileName()).toString();
+}
+
+void AppSettings::setCustAudioFileName(QString audio_file)
+{
+    m_settings->setValue("AudioName", audio_file);
+}
+
+QString AppSettings::defaultCustAudioFileName()
+{
+    return "Crow-translate.mp3";
+}
+
+//End my updates
+
 #ifdef WITH_PORTABLE_MODE
 bool AppSettings::isPortableModeEnabled() const
 {

--- a/src/settings/appsettings.h
+++ b/src/settings/appsettings.h
@@ -108,6 +108,31 @@ public:
     void setShowTrayIcon(bool visible);
     static bool defaultShowTrayIcon();
 
+    //For Workspace
+    void setEnableCustWorkSpace(bool enable);
+    bool isEnableCustWorkSpace() const;
+    static bool defaultEnableCustWorkSpace();
+    QString  getCustWorkSpace() const;
+    void setCustWorkSpace(QString path);
+    static QString defaultCustWorkSpace();
+
+    //For Custom File
+    void setEnableCustFileName(bool enable);
+    bool isEnableCustFileName() const;
+    static bool defaultEnableCustFileName();
+    QString  getCustFileName() const;
+    void setCustFileName(QString filename);
+    static QString defaultCustFileName();
+
+    //For Cust Audio File
+    void setEnableCustAudioFileName(bool enable);
+    bool isEnableCustAudioFileName() const;
+    static bool defaultEnableCustAudioFile();
+    QString  getCustAudioFileName() const;
+    void setCustAudioFileName(QString audio_file);
+    static QString defaultCustAudioFileName();
+    //End new updates
+
     bool isStartMinimized() const;
     void setStartMinimized(bool minimized);
     static bool defaultStartMinimized();

--- a/src/settings/settingsdialog.h
+++ b/src/settings/settingsdialog.h
@@ -21,7 +21,7 @@
 #define SETTINGSDIALOG_H
 
 #include "qonlinetts.h"
-
+#include "fileutil/fileutil.h"
 #include <QDialog>
 
 class MainWindow;
@@ -30,6 +30,9 @@ class QOnlineTranslator;
 class QMediaPlayer;
 class QMediaPlaylist;
 class ShortcutItem;
+class FileUtil;
+class ShowMsg;
+
 #ifdef WITH_PORTABLE_MODE
 class QCheckBox;
 #endif
@@ -56,6 +59,7 @@ public:
 public slots:
     void accept() override;
 
+
 private slots:
     void setCurrentPage(int index);
 
@@ -65,6 +69,14 @@ private slots:
     void onTrayIconTypeChanged(int type);
     void selectCustomTrayIcon();
     void setCustomTrayIconPreview(const QString &iconPath);
+
+    //Mines for Workspace and files .txt or .md and mp3
+    void onCustFileNameChanged(int mode);//To trate field Cust File Name
+    void onCustAudioTTSChanged(int mode);//To trate field Cust Audio File name
+    //
+    void onSelectWorkSpaceData(); //To Select new WorkSpace
+    void onValidFileNameData();   //To Validate data entry to File Name
+    void onValidAudioFileData();  //To Validate data entry to Audio Name
 
     void selectOcrLanguagesPath();
     void onOcrLanguagesPathChanged(const QString &path);
@@ -109,6 +121,10 @@ private:
     // Test voice
     QOnlineTranslator *m_yandexTranslator;
     QOnlineTranslator *m_googleTranslator;
+
+    //Work on Files
+    FileUtil * m_fileUtil;
+    ShowMsg * m_msg;
 
 #ifdef WITH_PORTABLE_MODE
     QCheckBox *m_portableCheckbox;

--- a/src/settings/settingsdialog.ui
+++ b/src/settings/settingsdialog.ui
@@ -127,7 +127,7 @@
          <x>0</x>
          <y>0</y>
          <width>626</width>
-         <height>609</height>
+         <height>608</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -281,6 +281,81 @@
                  </property>
                  <property name="text">
                   <string>Launch at startup</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="0">
+                <widget class="QLabel" name="workSpPathLabel">
+                 <property name="toolTip">
+                  <string>Path to write your content file...</string>
+                 </property>
+                 <property name="text">
+                  <string>Workspace:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="1">
+                <widget class="QLineEdit" name="workSpPathLineEdit">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="15" column="0">
+                <widget class="QLabel" name="fileNameLabel">
+                 <property name="toolTip">
+                  <string>Current file name to save..</string>
+                 </property>
+                 <property name="text">
+                  <string>File to Save:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="15" column="1">
+                <widget class="QLineEdit" name="fileNameLineEdit">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="18" column="0">
+                <widget class="QLabel" name="audioFileNameLabel">
+                 <property name="text">
+                  <string>Audio File to TTS:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="18" column="1">
+                <widget class="QLineEdit" name="audioFileNameLineEdit">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="toolTip">
+                  <string>Name to audio from TTS..</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="1">
+                <widget class="QCheckBox" name="custWorkSpPathCkBox">
+                 <property name="toolTip">
+                  <string>Check to edit default workspace...</string>
+                 </property>
+                 <property name="text">
+                  <string>Edit default Workspace..</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="14" column="1">
+                <widget class="QCheckBox" name="custFileNameCkBox">
+                 <property name="text">
+                  <string>Edit Current File to Save.</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="17" column="1">
+                <widget class="QCheckBox" name="custAudioToTTSCkBox">
+                 <property name="text">
+                  <string>Edit Default File to Save.</string>
                  </property>
                 </widget>
                </item>
@@ -2467,6 +2542,86 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>custWorkSpPathCkBox</sender>
+   <signal>stateChanged(int)</signal>
+   <receiver>SettingsDialog</receiver>
+   <slot>onSelectWorkSpaceData()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>627</x>
+     <y>291</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>424</x>
+     <y>329</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>custFileNameCkBox</sender>
+   <signal>stateChanged(int)</signal>
+   <receiver>SettingsDialog</receiver>
+   <slot>onCustFileNameChanged(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>627</x>
+     <y>359</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>424</x>
+     <y>329</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>custAudioToTTSCkBox</sender>
+   <signal>stateChanged(int)</signal>
+   <receiver>SettingsDialog</receiver>
+   <slot>onCustAudioTTSChanged(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>627</x>
+     <y>427</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>424</x>
+     <y>329</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>fileNameLineEdit</sender>
+   <signal>editingFinished()</signal>
+   <receiver>SettingsDialog</receiver>
+   <slot>onValidFileNameData()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>627</x>
+     <y>414</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>424</x>
+     <y>329</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>audioFileNameLineEdit</sender>
+   <signal>editingFinished()</signal>
+   <receiver>SettingsDialog</receiver>
+   <slot>onValidAudioFileData()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>627</x>
+     <y>482</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>424</x>
+     <y>329</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
  <slots>
   <slot>onProxyTypeChanged(int)</slot>
@@ -2492,5 +2647,10 @@
   <slot>onGoogleLanguageSelectionChanged(int)</slot>
   <slot>saveGoogleEngineRegion(int)</slot>
   <slot>detectGoogleTextLanguage()</slot>
+  <slot>onCustFileNameChanged(int)</slot>
+  <slot>onCustAudioTTSChanged(int)</slot>
+  <slot>onSelectWorkSpaceData()</slot>
+  <slot>onValidFileNameData()</slot>
+  <slot>onValidAudioFileData()</slot>
  </slots>
 </ui>

--- a/src/speakbuttons.cpp
+++ b/src/speakbuttons.cpp
@@ -180,6 +180,32 @@ void SpeakButtons::playPauseSpeaking()
         m_mediaPlayer->play();
 }
 
+QList<QString> SpeakButtons::getUrlToFileMp3(const QString &text, QOnlineTranslator::Language lang, QOnlineTranslator::Engine engine)
+{
+    QList<QString> m_strurl;
+
+    if (text.isEmpty()) {
+        QMessageBox::information(this, tr("No text specified"), tr("Playback text is empty"));
+        return m_strurl;
+    }
+
+    QOnlineTts onlineTts;
+    onlineTts.setRegions(m_googleRegions);
+
+    onlineTts.generateUrls(text, engine, lang, voice(engine), emotion(engine));
+    if (onlineTts.error() != QOnlineTts::NoError) {
+        QMessageBox::critical(this, tr("Unable to generate URLs for TTS"), onlineTts.errorString());
+        return m_strurl;
+    }
+
+// Use playlist to split long queries due engines limit
+//    const QList<QMediaContent> media = onlineTts.media();
+//    playlist()->clear();
+//    playlist()->addMedia(media);
+//    m_mediaPlayer->play();
+    return onlineTts.strurl();
+}
+
 void SpeakButtons::stopSpeaking()
 {
     m_mediaPlayer->stop();

--- a/src/speakbuttons.h
+++ b/src/speakbuttons.h
@@ -61,6 +61,8 @@ public:
     void speak(const QString &text, QOnlineTranslator::Language lang, QOnlineTranslator::Engine engine);
     void pauseSpeaking();
     void playPauseSpeaking();
+    QList<QString>  getUrlToFileMp3(const QString &text, QOnlineTranslator::Language lang, QOnlineTranslator::Engine engine);
+
 
 public slots:
     void stopSpeaking();


### PR DESCRIPTION
Some features I've added in my version that I think will be important for one type of person.
Added features to write a text file, which will be translated, as well as write the same to the translated text.
Save tts stream in a file with .mp3 extension. Sequential file if necessary. It will depend on the size of the stream for the read content.
Lets you define a new location to save files in the general menu. It also lets you define a custom name for the file.
Everything has been tested on linux 12 bookworm. I have no way to test on mac or windows system.