### PR TITLE
Fix translateSelection in wayland (#324)

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -729,15 +729,27 @@ void MainWindow::buildTranslateSelectionState(QState *state) const
     auto *showWindowState = new QState(state);
     auto *translationState = new QState(state);
     auto *finalState = new QFinalState(state);
-    state->setInitialState(setSelectionAsSourceState);
+
+    // On Wayland, the clipboard/selection content can only be obtained if the window is active
+    // so we need to show the window first
+    if (QGuiApplication::platformName() == QStringLiteral("wayland")) {
+        state->setInitialState(showWindowState);
+    } else {
+        state->setInitialState(setSelectionAsSourceState);
+    }
 
     connect(setSelectionAsSourceState, &QState::entered, this, &MainWindow::forceTranslationAutodetect);
     connect(showWindowState, &QState::entered, this, &MainWindow::showTranslationWindow);
     buildSetSelectionAsSourceState(setSelectionAsSourceState);
     buildTranslationState(translationState);
 
-    setSelectionAsSourceState->addTransition(setSelectionAsSourceState, &QState::finished, showWindowState);
-    showWindowState->addTransition(translationState);
+    if (QGuiApplication::platformName() == QStringLiteral("wayland")) {
+        showWindowState->addTransition(QGuiApplication::clipboard(), &QClipboard::selectionChanged, setSelectionAsSourceState);
+        setSelectionAsSourceState->addTransition(translationState);
+    } else {
+        setSelectionAsSourceState->addTransition(setSelectionAsSourceState, &QState::finished, showWindowState);
+        showWindowState->addTransition(translationState);
+    }
     translationState->addTransition(translationState, &QState::finished, finalState);
 }
 


### PR DESCRIPTION
Reference issue: #324 

English is not my native language, the following content uses Google Translate：

Both Qt and mainstream wayland desktop environments have supported  [primary-selection-unstable-v1.xml](https://wayland.app/protocols/primary-selection-unstable-v1#compositor-support).

In wayland, only the active window can read the latest clipboard/selection content, so just show the window first.

Test Environment:
- OS: Arch Linux x86_64
- Kernel: 6.4.5-arch1-1
- cmake version 3.27.0
- gcc version 13.1.1 20230714 (GCC)
- DE: Plasma Wayland (5.27.6) And Gnome Wayland (44.3)