### PR TITLE
Fix lingva.ml site offline

### DIFF
--- a/src/settings/appsettings.cpp
+++ b/src/settings/appsettings.cpp
@@ -550,7 +550,7 @@ QString AppSettings::defaultEngineUrl(QOnlineTranslator::Engine engine)
     case QOnlineTranslator::LibreTranslate:
         return QStringLiteral("https://translate.argosopentech.com");
     case QOnlineTranslator::Lingva:
-        return QStringLiteral("https://lingva.ml");
+        return QStringLiteral("https://lingva.garudalinux.org");
     default:
         Q_UNREACHABLE();
     }

--- a/src/settings/settingsdialog.ui
+++ b/src/settings/settingsdialog.ui
@@ -874,11 +874,11 @@
                   <bool>true</bool>
                  </property>
                  <property name="currentText">
-                  <string notr="true">https://lingva.ml</string>
+                  <string notr="true">https://lingva.garudalinux.org</string>
                  </property>
                  <item>
                   <property name="text">
-                   <string notr="true">https://lingva.ml</string>
+                   <string notr="true">https://lingva.garudalinux.org</string>
                   </property>
                  </item>
                  <item>


### PR DESCRIPTION
Official https://lingva.ml/ instance replaced with https://lingva.garudalinux.org/ (garuda linux instance)

fix: https://github.com/crow-translate/QOnlineTranslator/issues/60